### PR TITLE
Fixes formatting of order_statuses in cbadv::order::ListOrdersParams.to_params(), which  was causing cbadv::order::OrderAPI::get_bulk() to fail.

### DIFF
--- a/src/order.rs
+++ b/src/order.rs
@@ -320,8 +320,8 @@ impl ListOrdersParams {
 
         params = match &self.order_status {
             Some(v) => {
-                let statuses: String = v.iter().map(|s| s.to_string() + ",").collect();
-                format!("{}&order_status={}", params, statuses)
+                let statuses: String = v.iter().map(|s| format!("&order_status={s}")).collect();
+                format!("{}{}", params, statuses)
             }
             _ => params,
         };


### PR DESCRIPTION
### Description

I've run into an error while using ```cbadv::order::OrderAPI::get_bulk()```, with order statuses passed to its params.
It was giving me an error message containing: ```"order_status": "EXPIRED,CANCELLED," is not a valid value"```.

Looking into the format of the request, it seemed correct as shown on the documentation [here](https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_gethistoricalorders).

Looking a bit deeper it showed that they were formatting the request differently under the examples for different languages.

i.e instead of passing ```orders/historical/batch?order_status=CANCELLED,EXPIRED``` 

the examples on the right passed in ```batch?order_status=CANCELLED&order_status=EXPIRED```

Why this is the case I don't know.

### Fixes

changed the formatting for order statuses in ```ListOrdersParams.to_params()``` to match up with ```batch?order_status=CANCELLED&order_status=EXPIRED```.

### Tests

I used different combinations of order statuses and it works as expected.