### PR TITLE
Async callbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,9 +143,10 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cbadv"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "assert-json-diff",
+ "async-trait",
  "base64",
  "chrono",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cbadv"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 description = "Asynchronous Coinbase Advanced REST and WebSocket API"
 license = "MIT"
@@ -36,6 +36,7 @@ toml = { version = "0.8.19", optional = true }
 # WebSocket support
 tokio-tungstenite = { version = "0.24.0", features = ["native-tls"] }
 futures-util = "0.3.31"
+async-trait = "0.1.83"
 
 # Utilities
 uuid = { version = "1.11.0", features = [

--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ Full API documentation is available at [docs.rs](https://docs.rs/cbadv/latest/cb
 Client: `use cbadv::{WebSocketClient, WebSocketClientBuilder}`
 
 - **Authentication**: `client.connect`
-- **Subscribe**: `client.subscribe` or `client.sub`
-- **Unsubscribe**: `client.unsubscribe` or `client.unsub`
+- **Subscribe**: `client.subscribe`
+- **Unsubscribe**: `client.unsubscribe`
+- **Listen**: `client.listen`
 - **Channels Supported**:
   - `Channel::STATUS`: Status
   - `Channel::CANDLES`: Candles

--- a/examples/account_api.rs
+++ b/examples/account_api.rs
@@ -7,8 +7,8 @@
 
 use std::process::exit;
 
-use cbadv::account::AccountListQuery;
 use cbadv::config::{self, BaseConfig};
+use cbadv::models::account::AccountListQuery;
 use cbadv::RestClientBuilder;
 
 #[tokio::main]

--- a/examples/account_api.rs
+++ b/examples/account_api.rs
@@ -21,7 +21,7 @@ async fn main() {
         Err(err) => {
             println!("Could not load configuration file.");
             if config::exists("config.toml") {
-                println!("File exists, {}", err);
+                println!("File exists, {err}");
                 exit(1);
             }
 
@@ -36,7 +36,7 @@ async fn main() {
     let mut client = match RestClientBuilder::new().with_config(&config).build() {
         Ok(c) => c,
         Err(why) => {
-            eprintln!("!ERROR! {}", why);
+            eprintln!("!ERROR! {why}");
             exit(1)
         }
     };
@@ -48,12 +48,12 @@ async fn main() {
         .get_by_id(product_name, &AccountListQuery::new())
         .await
     {
-        Ok(account) => println!("{:#?}", account),
-        Err(error) => println!("Unable to get account: {}", error),
+        Ok(account) => println!("{account:#?}"),
+        Err(error) => println!("Unable to get account: {error}"),
     }
 
     // Pull accounts by ID.
-    let mut account_uuid = "".to_string();
+    let mut account_uuid = String::new();
     println!("\n\nObtaining ALL accounts (non-standard).");
     match client.account.get_all(&AccountListQuery::new()).await {
         Ok(accounts) => {
@@ -68,7 +68,7 @@ async fn main() {
                 None => println!("Out of bounds, could not find account."),
             }
         }
-        Err(error) => println!("Unable to get accounts: {}", error),
+        Err(error) => println!("Unable to get accounts: {error}"),
     }
 
     // Parameters to send to the API.
@@ -79,17 +79,17 @@ async fn main() {
     match client.account.get_bulk(&query).await {
         Ok(accounts) => {
             println!("Accounts obtained: {:#?}", accounts.accounts.len());
-            for acct in accounts.accounts.iter() {
+            for acct in &accounts.accounts {
                 println!("Account name: {}", acct.currency);
             }
         }
-        Err(error) => println!("Unable to get all accounts: {}", error),
+        Err(error) => println!("Unable to get all accounts: {error}"),
     }
 
     // Get a singular account based on the UUID.
-    println!("\n\nObtaining Account by UUID: {}", account_uuid);
+    println!("\n\nObtaining Account by UUID: {account_uuid}");
     match client.account.get(&account_uuid).await {
-        Ok(account) => println!("{:#?}", account),
-        Err(error) => println!("Unable to get account: {}", error),
+        Ok(account) => println!("{account:#?}"),
+        Err(error) => println!("Unable to get account: {error}"),
     }
 }

--- a/examples/convert_api.rs
+++ b/examples/convert_api.rs
@@ -7,7 +7,7 @@
 use std::process::exit;
 
 use cbadv::config::{self, BaseConfig};
-use cbadv::convert::{ConvertQuery, ConvertQuoteRequest};
+use cbadv::models::convert::{ConvertQuery, ConvertQuoteRequest};
 use cbadv::RestClientBuilder;
 
 #[tokio::main]

--- a/examples/convert_api.rs
+++ b/examples/convert_api.rs
@@ -22,7 +22,7 @@ async fn main() {
         Err(err) => {
             println!("Could not load configuration file.");
             if config::exists("config.toml") {
-                println!("File exists, {}", err);
+                println!("File exists, {err}");
                 exit(1);
             }
 
@@ -37,34 +37,33 @@ async fn main() {
     let mut client = match RestClientBuilder::new().with_config(&config).build() {
         Ok(c) => c,
         Err(why) => {
-            eprintln!("!ERROR! {}", why);
+            eprintln!("!ERROR! {why}");
             exit(1)
         }
     };
 
     // Create a quote to convert USDC to USD.
     println!(
-        "Creating a quote to convert {} {} to {}.",
-        amount, from_product, to_product
+        "Creating a quote to convert {amount} {from_product} to {to_product}."
     );
     let request = ConvertQuoteRequest::new(from_product, to_product, amount);
     let quote = match client.convert.create_quote(&request).await {
         Ok(q) => q,
         Err(why) => {
-            eprintln!("!ERROR! {}", why);
+            eprintln!("!ERROR! {why}");
             exit(1)
         }
     };
 
-    println!("Quote created: {:#?}", quote);
+    println!("Quote created: {quote:#?}");
     println!("\n\nObtain the quote with the quote_id: {}", quote.id);
     let query = ConvertQuery::new(from_product, to_product);
     match client.convert.get(&quote.id, &query).await {
         Ok(q) => {
-            println!("Quote obtained: {:#?}", q);
+            println!("Quote obtained: {q:#?}");
         }
         Err(why) => {
-            eprintln!("!ERROR! {}", why);
+            eprintln!("!ERROR! {why}");
             exit(1)
         }
     };

--- a/examples/custom_config.rs
+++ b/examples/custom_config.rs
@@ -54,7 +54,7 @@ async fn main() {
         Err(err) => {
             println!("Could not load configuration file.");
             if config::exists("config.toml") {
-                println!("File exists, {}", err);
+                println!("File exists, {err}");
                 exit(1);
             }
 
@@ -69,7 +69,7 @@ async fn main() {
     let mut client = match RestClientBuilder::new().with_config(&config).build() {
         Ok(c) => c,
         Err(why) => {
-            eprintln!("!ERROR! {}", why);
+            eprintln!("!ERROR! {why}");
             exit(1)
         }
     };
@@ -79,9 +79,9 @@ async fn main() {
     let product = match client.product.get(&config.general.product_id).await {
         Ok(p) => p,
         Err(err) => {
-            println!("{}", err);
+            println!("{err}");
             exit(1);
         }
     };
-    println!("{:#?}\n\n", product);
+    println!("{product:#?}\n\n");
 }

--- a/examples/data_api.rs
+++ b/examples/data_api.rs
@@ -16,7 +16,7 @@ async fn main() {
         Err(err) => {
             println!("Could not load configuration file.");
             if config::exists("config.toml") {
-                println!("File exists, {}", err);
+                println!("File exists, {err}");
                 exit(1);
             }
 
@@ -31,7 +31,7 @@ async fn main() {
     let mut client = match RestClientBuilder::new().with_config(&config).build() {
         Ok(c) => c,
         Err(why) => {
-            eprintln!("!ERROR! {}", why);
+            eprintln!("!ERROR! {why}");
             exit(1)
         }
     };
@@ -39,7 +39,7 @@ async fn main() {
     // Get the API key permissions.
     println!("Obtaining Key Permissions for the API key.");
     match client.data.key_permissions().await {
-        Ok(perm) => println!("{:#?}", perm),
-        Err(error) => println!("Unable to get the API key permissions: {}", error),
+        Ok(perm) => println!("{perm:#?}"),
+        Err(error) => println!("Unable to get the API key permissions: {error}"),
     }
 }

--- a/examples/fee_api.rs
+++ b/examples/fee_api.rs
@@ -6,8 +6,8 @@
 use std::process::exit;
 
 use cbadv::config::{self, BaseConfig};
-use cbadv::fee::FeeTransactionSummaryQuery;
-use cbadv::product::ProductType;
+use cbadv::models::fee::FeeTransactionSummaryQuery;
+use cbadv::models::product::ProductType;
 use cbadv::RestClientBuilder;
 
 #[tokio::main]

--- a/examples/fee_api.rs
+++ b/examples/fee_api.rs
@@ -18,7 +18,7 @@ async fn main() {
         Err(err) => {
             println!("Could not load configuration file.");
             if config::exists("config.toml") {
-                println!("File exists, {}", err);
+                println!("File exists, {err}");
                 exit(1);
             }
 
@@ -33,7 +33,7 @@ async fn main() {
     let mut client = match RestClientBuilder::new().with_config(&config).build() {
         Ok(c) => c,
         Err(why) => {
-            eprintln!("!ERROR! {}", why);
+            eprintln!("!ERROR! {why}");
             exit(1)
         }
     };
@@ -44,7 +44,7 @@ async fn main() {
     // Get fee transaction summary.
     println!("Obtaining Transaction Fee Summary");
     match client.fee.get(&params).await {
-        Ok(summary) => println!("{:#?}", summary),
-        Err(error) => println!("Unable to get the Transaction Summary: {}", error),
+        Ok(summary) => println!("{summary:#?}"),
+        Err(error) => println!("Unable to get the Transaction Summary: {error}"),
     }
 }

--- a/examples/order_api.rs
+++ b/examples/order_api.rs
@@ -12,7 +12,7 @@ use std::process::exit;
 use std::thread;
 
 use cbadv::config::{self, BaseConfig};
-use cbadv::order::{
+use cbadv::models::order::{
     OrderCancelRequest, OrderCreateBuilder, OrderEditRequest, OrderListQuery, OrderSide,
     OrderStatus, OrderType, TimeInForce,
 };

--- a/examples/order_api.rs
+++ b/examples/order_api.rs
@@ -37,7 +37,7 @@ async fn main() {
     {
         Ok(order) => order,
         Err(error) => {
-            println!("Unable to build order: {}", error);
+            println!("Unable to build order: {error}");
             exit(1);
         }
     };
@@ -48,7 +48,7 @@ async fn main() {
         Err(err) => {
             println!("Could not load configuration file.");
             if config::exists("config.toml") {
-                println!("File exists, {}", err);
+                println!("File exists, {err}");
                 exit(1);
             }
 
@@ -63,7 +63,7 @@ async fn main() {
     let mut client = match RestClientBuilder::new().with_config(&config).build() {
         Ok(c) => c,
         Err(why) => {
-            eprintln!("!ERROR! {}", why);
+            eprintln!("!ERROR! {why}");
             exit(1)
         }
     };
@@ -78,9 +78,9 @@ async fn main() {
                 if let Some(success) = &summary.success_response {
                     created_order_id = Some(success.order_id.clone());
                 }
-                println!("Order creation result: {:#?}", summary);
+                println!("Order creation result: {summary:#?}");
             }
-            Err(error) => println!("Unable to create order: {}", error),
+            Err(error) => println!("Unable to create order: {error}"),
         }
     }
 
@@ -88,49 +88,49 @@ async fn main() {
         if create_new && edit_created {
             thread::sleep(Duration::seconds(1).to_std().unwrap());
             let edit_order = OrderEditRequest::new(order_id, 50.0, 0.006);
-            println!("\n\nEditing order for {}.", order_id);
+            println!("\n\nEditing order for {order_id}.");
             match client.order.edit(&edit_order).await {
-                Ok(result) => println!("{:#?}", result),
-                Err(error) => println!("Unable to edit order: {}", error),
+                Ok(result) => println!("{result:#?}"),
+                Err(error) => println!("Unable to edit order: {error}"),
             }
         }
     }
 
     if let Some(order_id) = &created_order_id {
         if create_new && cancel_created {
-            println!("\n\nCancelling Order with ID: {}", order_id);
+            println!("\n\nCancelling Order with ID: {order_id}");
             match client
                 .order
                 .cancel(&OrderCancelRequest::new(&[order_id.clone()]))
                 .await
             {
-                Ok(summary) => println!("Order cancel result: {:#?}", summary),
-                Err(error) => println!("Unable to cancel order: {}", error),
+                Ok(summary) => println!("Order cancel result: {summary:#?}"),
+                Err(error) => println!("Unable to cancel order: {error}"),
             }
         }
     }
 
     // Cancels all OPEN orders.
     if cancel_all {
-        println!("\n\nCancelling all OPEN orders for {}.", product_id);
+        println!("\n\nCancelling all OPEN orders for {product_id}.");
         match client.order.cancel_all(product_id).await {
-            Ok(result) => println!("{:#?}", result),
-            Err(error) => println!("Unable to cancel orders: {}", error),
+            Ok(result) => println!("{result:#?}"),
+            Err(error) => println!("Unable to cancel orders: {error}"),
         }
     }
 
-    println!("\n\nGetting all orders for {} (get_all).", product_id);
+    println!("\n\nGetting all orders for {product_id} (get_all).");
     match client
         .order
         .get_all(product_id, &OrderListQuery::new())
         .await
     {
         Ok(orders) => println!("Orders obtained: {:#?}", orders.len()),
-        Err(error) => println!("Unable to obtain all orders: {}", error),
+        Err(error) => println!("Unable to obtain all orders: {error}"),
     }
 
     // Get all BUYING orders.
-    let mut order_id = "".to_string();
+    let mut order_id = String::new();
     let query = OrderListQuery {
         product_ids: Some(vec![product_id.to_string()]),
         order_side: Some(OrderSide::Buy),
@@ -144,7 +144,7 @@ async fn main() {
             match orders.orders.first() {
                 Some(order) => {
                     order_id = order.order_id.clone();
-                    println!("{:#?}", order);
+                    println!("{order:#?}");
                 }
                 None => println!("Out of bounds, no orders exist."),
             }
@@ -165,18 +165,18 @@ async fn main() {
                     .cancel(&OrderCancelRequest::new(&order_ids))
                     .await
                 {
-                    Ok(summary) => println!("Order cancel result: {:#?}", summary),
-                    Err(error) => println!("Unable to cancel order: {}", error),
+                    Ok(summary) => println!("Order cancel result: {summary:#?}"),
+                    Err(error) => println!("Unable to cancel order: {error}"),
                 }
             }
         }
-        Err(error) => println!("Unable to obtain bulk or cancel orders: {}", error),
+        Err(error) => println!("Unable to obtain bulk or cancel orders: {error}"),
     }
 
     // Get a singular order based on the ID.
-    println!("\n\nObtaining single order: {}", order_id);
+    println!("\n\nObtaining single order: {order_id}");
     match client.order.get(&order_id).await {
-        Ok(order) => println!("{:#?}", order),
-        Err(error) => println!("Unable to get single order: {}", error),
+        Ok(order) => println!("{order:#?}"),
+        Err(error) => println!("Unable to get single order: {error}"),
     }
 }

--- a/examples/order_api.rs
+++ b/examples/order_api.rs
@@ -27,7 +27,7 @@ async fn main() {
     let cancel_all: bool = false;
     let product_id: &str = "ETH-USDC";
     let mut created_order_id: Option<String> = None;
-    let new_order = match OrderCreateBuilder::new(product_id, &OrderSide::Buy)
+    let new_order = match OrderCreateBuilder::new(product_id, OrderSide::Buy)
         .base_size(0.005)
         .limit_price(100.0)
         .post_only(true)

--- a/examples/payment_api.rs
+++ b/examples/payment_api.rs
@@ -17,7 +17,7 @@ async fn main() {
         Err(err) => {
             println!("Could not load configuration file.");
             if config::exists("config.toml") {
-                println!("File exists, {}", err);
+                println!("File exists, {err}");
                 exit(1);
             }
 
@@ -32,7 +32,7 @@ async fn main() {
     let mut client = match RestClientBuilder::new().with_config(&config).build() {
         Ok(c) => c,
         Err(why) => {
-            eprintln!("!ERROR! {}", why);
+            eprintln!("!ERROR! {why}");
             exit(1)
         }
     };
@@ -43,12 +43,12 @@ async fn main() {
     println!("Obtaining all payment methods.");
     match client.payment.get_all().await {
         Ok(methods) => {
-            println!("{:#?}", methods);
+            println!("{methods:#?}");
             if let Some(method) = methods.first() {
                 payment_method_id = Some(method.id.clone());
             }
         }
-        Err(error) => println!("Unable to get the Payment Methods: {}", error),
+        Err(error) => println!("Unable to get the Payment Methods: {error}"),
     }
 
     // Obtain a single payment method.
@@ -56,8 +56,8 @@ async fn main() {
         // Get a single payment method.
         println!("\n\nObtaining a single payment method.");
         match client.payment.get(&payment_method_id).await {
-            Ok(method) => println!("{:#?}", method),
-            Err(error) => println!("Unable to get the Payment Method: {}", error),
+            Ok(method) => println!("{method:#?}"),
+            Err(error) => println!("Unable to get the Payment Method: {error}"),
         }
     }
 }

--- a/examples/portfolio_api.rs
+++ b/examples/portfolio_api.rs
@@ -10,7 +10,9 @@
 use std::process::exit;
 
 use cbadv::config::{self, BaseConfig};
-use cbadv::portfolio::{PortfolioBreakdownQuery, PortfolioListQuery, PortfolioModifyRequest};
+use cbadv::models::portfolio::{
+    PortfolioBreakdownQuery, PortfolioListQuery, PortfolioModifyRequest,
+};
 use cbadv::RestClientBuilder;
 
 #[tokio::main]

--- a/examples/portfolio_api.rs
+++ b/examples/portfolio_api.rs
@@ -36,7 +36,7 @@ async fn main() {
         Err(err) => {
             println!("Could not load configuration file.");
             if config::exists("config.toml") {
-                println!("File exists, {}", err);
+                println!("File exists, {err}");
                 exit(1);
             }
 
@@ -51,7 +51,7 @@ async fn main() {
     let mut client = match RestClientBuilder::new().with_config(&config).build() {
         Ok(c) => c,
         Err(why) => {
-            eprintln!("!ERROR! {}", why);
+            eprintln!("!ERROR! {why}");
             exit(1)
         }
     };
@@ -60,8 +60,8 @@ async fn main() {
     if let Some(name) = create_portfolio_name {
         println!("Creating Portfolio.");
         match client.portfolio.create(name).await {
-            Ok(portfolio) => println!("{:#?}", portfolio),
-            Err(error) => println!("Unable to create the portfolio: {}", error),
+            Ok(portfolio) => println!("{portfolio:#?}"),
+            Err(error) => println!("Unable to create the portfolio: {error}"),
         }
     }
 
@@ -70,8 +70,8 @@ async fn main() {
         println!("Editing Portfolio.");
         let request = PortfolioModifyRequest::new(edit_portfolio_name);
         match client.portfolio.edit(uuid, &request).await {
-            Ok(portfolio) => println!("{:#?}", portfolio),
-            Err(error) => println!("Unable to edit the portfolio: {}", error),
+            Ok(portfolio) => println!("{portfolio:#?}"),
+            Err(error) => println!("Unable to edit the portfolio: {error}"),
         }
     }
 
@@ -79,8 +79,8 @@ async fn main() {
     if let Some(uuid) = delete_portfolio_uuid {
         println!("Deleting Portfolio.");
         match client.portfolio.delete(uuid).await {
-            Ok(_) => println!("Portfolio deleted!"),
-            Err(error) => println!("Unable to delete the portfolio: {}", error),
+            Ok(()) => println!("Portfolio deleted!"),
+            Err(error) => println!("Unable to delete the portfolio: {error}"),
         }
     }
 
@@ -91,25 +91,25 @@ async fn main() {
     println!("Obtaining Portfolios");
     let breakdown_uuid = match client.portfolio.get_all(&query).await {
         Ok(portfolios) => {
-            println!("{:#?}", portfolios);
+            println!("{portfolios:#?}");
             Some(portfolios.first().unwrap().uuid.clone())
         }
         Err(error) => {
-            println!("Unable to get the portfolios: {}", error);
+            println!("Unable to get the portfolios: {error}");
             None
         }
     };
 
     // Get the breakdown for the first portfolio.
     if let Some(uuid) = breakdown_uuid {
-        println!("Obtaining Portfolio Breakdown for {}.", uuid);
+        println!("Obtaining Portfolio Breakdown for {uuid}.");
         match client
             .portfolio
             .get(&uuid, &PortfolioBreakdownQuery::new())
             .await
         {
-            Ok(breakdown) => println!("{:#?}", breakdown),
-            Err(error) => println!("Unable to get the breakdown: {}", error),
+            Ok(breakdown) => println!("{breakdown:#?}"),
+            Err(error) => println!("Unable to get the breakdown: {error}"),
         }
     }
 }

--- a/examples/product_api.rs
+++ b/examples/product_api.rs
@@ -26,7 +26,7 @@ async fn main() {
         Err(err) => {
             println!("Could not load configuration file.");
             if config::exists("config.toml") {
-                println!("File exists, {}", err);
+                println!("File exists, {err}");
                 exit(1);
             }
 
@@ -41,21 +41,21 @@ async fn main() {
     let mut client = match RestClientBuilder::new().with_config(&config).build() {
         Ok(c) => c,
         Err(why) => {
-            eprintln!("!ERROR! {}", why);
+            eprintln!("!ERROR! {why}");
             exit(1)
         }
     };
 
     // Pull a singular product from the Product API.
-    println!("Getting product: {}.", product_pair);
+    println!("Getting product: {product_pair}.");
     let product = client.product.get(product_pair).await.unwrap();
-    println!("{:#?}\n\n", product);
+    println!("{product:#?}\n\n");
 
     println!("Getting best bids and asks.");
     let query = ProductBidAskQuery::new().product_ids(&["BTC-USD".to_string()]);
     match client.product.best_bid_ask(&query).await {
-        Ok(bidasks) => println!("{:#?}", bidasks),
-        Err(error) => println!("Unable to get best bids and asks: {}", error),
+        Ok(bidasks) => println!("{bidasks:#?}"),
+        Err(error) => println!("Unable to get best bids and asks: {error}"),
     }
 
     // NOTE: Commented out due to large amounts of output.
@@ -71,13 +71,13 @@ async fn main() {
     // Pull multiple products from the Product API.
     match client.product.get_bulk(&query).await {
         Ok(products) => println!("Obtained {:#?} products", products.len()),
-        Err(error) => println!("Unable to get products: {}", error),
+        Err(error) => println!("Unable to get products: {error}"),
     }
 
     // Pull candles.
     let end = time::now();
-    let interval = Granularity::to_secs(&Granularity::OneDay) as u64;
-    println!("\n\nGetting candles for: {}.", product_pair);
+    let interval = u64::from(Granularity::to_secs(&Granularity::OneDay));
+    println!("\n\nGetting candles for: {product_pair}.");
     let query = ProductCandleQuery::new(
         time::before(end, interval * 365),
         end,
@@ -88,15 +88,15 @@ async fn main() {
         Ok(candles) => {
             println!("Obtained {} candles.", candles.len());
             match candles.first() {
-                Some(candle) => println!("{:#?}", candle),
+                Some(candle) => println!("{candle:#?}"),
                 None => println!("Out of bounds, no candles obtained."),
             }
         }
-        Err(error) => println!("Unable to get candles: {}", error),
+        Err(error) => println!("Unable to get candles: {error}"),
     }
 
     // Pull ticker.
-    println!("\n\nGetting ticker for: {}.", product_pair);
+    println!("\n\nGetting ticker for: {product_pair}.");
     let query = ProductTickerQuery::new(200);
     match client.product.ticker(product_pair, &query).await {
         Ok(ticker) => {
@@ -107,10 +107,10 @@ async fn main() {
                 ticker.trades.len()
             );
             match ticker.trades.first() {
-                Some(trade) => println!("{:#?}", trade),
+                Some(trade) => println!("{trade:#?}"),
                 None => println!("Out of bounds, no trades available."),
             }
         }
-        Err(error) => println!("Unable to get ticker: {}", error),
+        Err(error) => println!("Unable to get ticker: {error}"),
     }
 }

--- a/examples/product_api.rs
+++ b/examples/product_api.rs
@@ -10,7 +10,7 @@
 use std::process::exit;
 
 use cbadv::config::{self, BaseConfig};
-use cbadv::product::{
+use cbadv::models::product::{
     ProductBidAskQuery, ProductCandleQuery, ProductListQuery, ProductTickerQuery,
 };
 use cbadv::time::Granularity;

--- a/examples/public_api.rs
+++ b/examples/public_api.rs
@@ -21,7 +21,7 @@ async fn main() {
     let mut client = match RestClientBuilder::new().build() {
         Ok(c) => c,
         Err(why) => {
-            eprintln!("!ERROR! {}", why);
+            eprintln!("!ERROR! {why}");
             exit(1)
         }
     };
@@ -29,8 +29,8 @@ async fn main() {
     // Get API Unix time.
     println!("Obtaining API Unix time");
     match client.public.time().await {
-        Ok(time) => println!("{:#?}", time),
-        Err(error) => println!("Unable to get the Unix time: {}", error),
+        Ok(time) => println!("{time:#?}"),
+        Err(error) => println!("Unable to get the Unix time: {error}"),
     }
 
     // NOTE: Commented out due to large amounts of output.
@@ -52,13 +52,13 @@ async fn main() {
     // Pull multiple products from the Product API.
     match client.public.products(&query).await {
         Ok(products) => println!("Obtained {:#?} products", products.len()),
-        Err(error) => println!("Unable to get products: {}", error),
+        Err(error) => println!("Unable to get products: {error}"),
     }
 
     // Pull candles.
     let end = time::now();
-    let interval = Granularity::to_secs(&Granularity::OneDay) as u64;
-    println!("\n\nGetting candles for: {}.", product_pair);
+    let interval = u64::from(Granularity::to_secs(&Granularity::OneDay));
+    println!("\n\nGetting candles for: {product_pair}.");
     let query = ProductCandleQuery::new(
         time::before(end, interval * 365),
         end,
@@ -69,15 +69,15 @@ async fn main() {
         Ok(candles) => {
             println!("Obtained {} candles.", candles.len());
             match candles.first() {
-                Some(candle) => println!("{:#?}", candle),
+                Some(candle) => println!("{candle:#?}"),
                 None => println!("Out of bounds, no candles obtained."),
             }
         }
-        Err(error) => println!("Unable to get candles: {}", error),
+        Err(error) => println!("Unable to get candles: {error}"),
     }
 
     // Pull ticker.
-    println!("\n\nGetting ticker for: {}.", product_pair);
+    println!("\n\nGetting ticker for: {product_pair}.");
     let query = ProductTickerQuery::new(200);
     match client.public.ticker(product_pair, &query).await {
         Ok(ticker) => {
@@ -88,10 +88,10 @@ async fn main() {
                 ticker.trades.len()
             );
             match ticker.trades.first() {
-                Some(trade) => println!("{:#?}", trade),
+                Some(trade) => println!("{trade:#?}"),
                 None => println!("Out of bounds, no trades available."),
             }
         }
-        Err(error) => println!("Unable to get ticker: {}", error),
+        Err(error) => println!("Unable to get ticker: {error}"),
     }
 }

--- a/examples/public_api.rs
+++ b/examples/public_api.rs
@@ -9,7 +9,7 @@
 
 use std::process::exit;
 
-use cbadv::product::{ProductCandleQuery, ProductListQuery, ProductTickerQuery};
+use cbadv::models::product::{ProductCandleQuery, ProductListQuery, ProductTickerQuery};
 use cbadv::time::Granularity;
 use cbadv::{time, RestClientBuilder};
 

--- a/examples/sandbox_api.rs
+++ b/examples/sandbox_api.rs
@@ -55,7 +55,7 @@ async fn main() {
 
     // Create an order request using the `OrderCreateBuilder`.
     // This example creates a Limit Order that is Good-Til-Cancelled (GTC) and post-only.
-    let order = match OrderCreateBuilder::new(product_pair, &side)
+    let order = match OrderCreateBuilder::new(product_pair, side)
         .base_size(total_size)
         .limit_price(price)
         .post_only(true)

--- a/examples/sandbox_api.rs
+++ b/examples/sandbox_api.rs
@@ -11,7 +11,9 @@
 use std::process::exit;
 
 use cbadv::config::{self, BaseConfig};
-use cbadv::order::{OrderCreateBuilder, OrderEditRequest, OrderSide, OrderType, TimeInForce};
+use cbadv::models::order::{
+    OrderCreateBuilder, OrderEditRequest, OrderSide, OrderType, TimeInForce,
+};
 use cbadv::RestClientBuilder;
 
 #[tokio::main]

--- a/examples/sandbox_api.rs
+++ b/examples/sandbox_api.rs
@@ -29,7 +29,7 @@ async fn main() {
         Err(err) => {
             println!("Could not load configuration file.");
             if config::exists("config.toml") {
-                println!("File exists, {}", err);
+                println!("File exists, {err}");
                 exit(1);
             }
 
@@ -48,7 +48,7 @@ async fn main() {
     {
         Ok(c) => c,
         Err(why) => {
-            eprintln!("!ERROR! {}", why);
+            eprintln!("!ERROR! {why}");
             exit(1)
         }
     };
@@ -66,27 +66,27 @@ async fn main() {
     {
         Ok(order) => order,
         Err(error) => {
-            println!("Unable to build order: {}", error);
+            println!("Unable to build order: {error}");
             exit(1);
         }
     };
 
-    println!("Creating Order for {}.", product_pair);
+    println!("Creating Order for {product_pair}.");
     match client.order.create(&order).await {
-        Ok(summary) => println!("Order creation result: {:#?}", summary),
-        Err(error) => println!("Unable to create order: {}", error),
+        Ok(summary) => println!("Order creation result: {summary:#?}"),
+        Err(error) => println!("Unable to create order: {error}"),
     }
 
     println!("\n\nPreviewing an order creation.");
     match client.order.preview_create(&order).await {
-        Ok(summary) => println!("Order preview result: {:#?}", summary),
-        Err(error) => println!("Unable to preview order: {}", error),
+        Ok(summary) => println!("Order preview result: {summary:#?}"),
+        Err(error) => println!("Unable to preview order: {error}"),
     }
 
     println!("\n\nPreviewing an order edit.");
     let edit_preview = OrderEditRequest::new("order_id", 100.00, 0.005);
     match client.order.preview_edit(&edit_preview).await {
-        Ok(summary) => println!("Order edit preview result: {:#?}", summary),
-        Err(error) => println!("Unable to preview order edit: {}", error),
+        Ok(summary) => println!("Order edit preview result: {summary:#?}"),
+        Err(error) => println!("Unable to preview order edit: {error}"),
     }
 }

--- a/examples/watch_candles.rs
+++ b/examples/watch_candles.rs
@@ -56,7 +56,7 @@ async fn get_products(client: &mut RestClient) -> Vec<String> {
                 })
                 .collect();
         }
-        Err(error) => println!("Unable to get products: {}", error),
+        Err(error) => println!("Unable to get products: {error}"),
     }
 
     product_names
@@ -68,7 +68,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
     let mut rclient = match RestClientBuilder::new().build() {
         Ok(c) => c,
         Err(why) => {
-            eprintln!("!ERROR! {}", why);
+            eprintln!("!ERROR! {why}");
             exit(1)
         }
     };
@@ -81,7 +81,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
     {
         Ok(c) => c,
         Err(why) => {
-            eprintln!("!ERROR! {}", why);
+            eprintln!("!ERROR! {why}");
             exit(1)
         }
     };
@@ -99,15 +99,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
     let task = match wsclient.watch_candles(&products, mystruct).await {
         Ok(value) => value,
         Err(err) => {
-            println!("Could not watch candles: {}", err);
+            println!("Could not watch candles: {err}");
             exit(1);
         }
     };
 
     // Wait to join the task.
     match task.await {
-        Ok(_) => println!("Task is complete."),
-        Err(err) => println!("Task ended in error: {}", err),
+        Ok(()) => println!("Task is complete."),
+        Err(err) => println!("Task ended in error: {err}"),
     };
 
     Ok(())

--- a/examples/watch_candles.rs
+++ b/examples/watch_candles.rs
@@ -8,7 +8,7 @@
 
 use std::process::exit;
 
-use cbadv::product::{Candle, ProductListQuery};
+use cbadv::models::product::{Candle, ProductListQuery};
 use cbadv::traits::CandleCallback;
 use cbadv::{RestClient, RestClientBuilder, WebSocketClientBuilder};
 

--- a/examples/watch_candles.rs
+++ b/examples/watch_candles.rs
@@ -10,7 +10,7 @@ use std::process::exit;
 
 use cbadv::models::product::{Candle, ProductListQuery};
 use cbadv::traits::CandleCallback;
-use cbadv::{RestClient, RestClientBuilder, WebSocketClientBuilder};
+use cbadv::{async_trait, RestClient, RestClientBuilder, WebSocketClientBuilder};
 
 /// Example of user-defined struct to pass to the candle watcher.
 pub struct UserStruct {
@@ -18,8 +18,9 @@ pub struct UserStruct {
     processed: usize,
 }
 
+#[async_trait]
 impl CandleCallback for UserStruct {
-    fn candle_callback(&mut self, current_start: u64, product_id: String, candle: Candle) {
+    async fn candle_callback(&mut self, current_start: u64, product_id: String, candle: Candle) {
         self.processed += 1;
 
         let mut is_same = "";

--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -16,12 +16,12 @@ use cbadv::{FunctionCallback, WebSocketClientBuilder};
 /// the stream.
 fn message_callback(msg: CbResult<Message>) {
     let rcvd = match msg {
-        Ok(message) => format!("{:?}", message), // Leverage Debug for all Message variants
-        Err(error) => format!("Error: {}", error), // Handle WebSocket errors
+        Ok(message) => format!("{message:?}"), // Leverage Debug for all Message variants
+        Err(error) => format!("Error: {error}"), // Handle WebSocket errors
     };
 
     // Update the callback object's properties and log the message.
-    println!("{}\n", rcvd);
+    println!("{rcvd}\n");
 }
 
 #[tokio::main]
@@ -32,7 +32,7 @@ async fn main() {
         .max_retries(20)
         .build()
         .map_err(|e| {
-            eprintln!("!ERROR! {}", e);
+            eprintln!("!ERROR! {e}");
             exit(1);
         })
         .unwrap();

--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -8,54 +8,26 @@
 
 use std::process::exit;
 
-use cbadv::config::{self, BaseConfig};
-use cbadv::traits::MessageCallback;
 use cbadv::types::CbResult;
 use cbadv::ws::{Channel, EndpointType, Message};
-use cbadv::WebSocketClientBuilder;
+use cbadv::{FunctionCallback, WebSocketClientBuilder};
 
-/// Example of an object with an attached callback function for messages.
-struct CallbackObject {
-    /// Total amount of messages processed.
-    total_processed: usize,
-}
+/// This is used to parse messages. It is passed to the `listen` function to pull Messages out of
+/// the stream.
+fn message_callback(msg: CbResult<Message>) {
+    let rcvd = match msg {
+        Ok(message) => format!("{:?}", message), // Leverage Debug for all Message variants
+        Err(error) => format!("Error: {}", error), // Handle WebSocket errors
+    };
 
-impl MessageCallback for CallbackObject {
-    /// This is used to parse messages. It is passed to the `listen` function to pull Messages out of
-    /// the stream.
-    fn message_callback(&mut self, msg: CbResult<Message>) {
-        let rcvd = match msg {
-            Ok(message) => format!("{:?}", message), // Leverage Debug for all Message variants
-            Err(error) => format!("Error: {}", error), // Handle WebSocket errors
-        };
-
-        // Update the callback object's properties and log the message.
-        self.total_processed += 1;
-        println!("{:<5}> {}\n", self.total_processed, rcvd);
-    }
+    // Update the callback object's properties and log the message.
+    println!("{}\n", rcvd);
 }
 
 #[tokio::main]
 async fn main() {
-    // Load the configuration file.
-    let config: BaseConfig = match config::load("config.toml") {
-        Ok(c) => c,
-        Err(err) => {
-            println!("Could not load configuration file.");
-            if config::exists("config.toml") {
-                println!("File exists, {}", err);
-                exit(1);
-            }
-
-            // Create a new configuration file.
-            config::create_base_config("config.toml").unwrap();
-            println!("Empty configuration file created, please update it.");
-            exit(1);
-        }
-    };
-
+    // Create a client that can only access private streams.
     let mut client = WebSocketClientBuilder::new()
-        .with_config(&config)
         .auto_reconnect(true)
         .max_retries(20)
         .build()
@@ -65,8 +37,8 @@ async fn main() {
         })
         .unwrap();
 
-    // Callback Object.
-    let cb_obj = CallbackObject { total_processed: 0 };
+    // Assign the callback function to an object.
+    let callback = FunctionCallback::from_sync(message_callback);
 
     // Connect to the websocket, a subscription needs to be sent within 5 seconds.
     // If a subscription is not sent, Coinbase will close the connection.
@@ -82,7 +54,7 @@ async fn main() {
     let listened_client = client.clone();
     let listener = tokio::spawn(async move {
         let mut listened_client = listened_client;
-        listened_client.listen_trait(public, cb_obj).await;
+        listened_client.listen(public, callback).await;
     });
 
     // Products of interest.
@@ -90,9 +62,6 @@ async fn main() {
 
     // Heartbeats is a great way to keep a connection alive and not timeout.
     client.sub(&Channel::Heartbeats, &[]).await.unwrap();
-
-    // Subscribe to user orders.
-    client.sub(&Channel::User, &products).await.unwrap();
 
     // Get updates (subscribe) on products and currencies.
     client.sub(&Channel::Candles, &products).await.unwrap();

--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -61,13 +61,19 @@ async fn main() {
     let products = vec!["BTC-USD".to_string(), "ETH-USD".to_string()];
 
     // Heartbeats is a great way to keep a connection alive and not timeout.
-    client.sub(&Channel::Heartbeats, &[]).await.unwrap();
+    client.subscribe(&Channel::Heartbeats, &[]).await.unwrap();
 
     // Get updates (subscribe) on products and currencies.
-    client.sub(&Channel::Candles, &products).await.unwrap();
+    client
+        .subscribe(&Channel::Candles, &products)
+        .await
+        .unwrap();
 
     // Stop obtaining (unsubscribe) updates on products and currencies.
-    client.unsub(&Channel::Status, &products).await.unwrap();
+    client
+        .unsubscribe(&Channel::Status, &products)
+        .await
+        .unwrap();
 
     // Passes the parser callback and listens for messages.
     listener.await.unwrap();

--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -8,8 +8,8 @@
 
 use std::process::exit;
 
+use cbadv::models::websocket::{Channel, EndpointType, Message};
 use cbadv::types::CbResult;
-use cbadv::ws::{Channel, EndpointType, Message};
 use cbadv::{FunctionCallback, WebSocketClientBuilder};
 
 /// This is used to parse messages. It is passed to the `listen` function to pull Messages out of

--- a/examples/websocket_user.rs
+++ b/examples/websocket_user.rs
@@ -9,9 +9,9 @@
 use std::process::exit;
 
 use cbadv::config::{self, BaseConfig};
+use cbadv::models::websocket::{Channel, EndpointType, Message};
 use cbadv::traits::MessageCallback;
 use cbadv::types::CbResult;
-use cbadv::ws::{Channel, EndpointType, Message};
 use cbadv::{async_trait, WebSocketClientBuilder};
 
 /// Example of an object with an attached callback function for messages.

--- a/examples/websocket_user.rs
+++ b/examples/websocket_user.rs
@@ -87,10 +87,10 @@ async fn main() {
     });
 
     // Heartbeats is a great way to keep a connection alive and not timeout.
-    client.sub(&Channel::Heartbeats, &[]).await.unwrap();
+    client.subscribe(&Channel::Heartbeats, &[]).await.unwrap();
 
     // Subscribe to user orders.
-    client.sub(&Channel::User, &[]).await.unwrap();
+    client.subscribe(&Channel::User, &[]).await.unwrap();
 
     // Passes the parser callback and listens for messages.
     listener.await.unwrap();

--- a/examples/websocket_user.rs
+++ b/examples/websocket_user.rs
@@ -26,8 +26,8 @@ impl MessageCallback for CallbackObject {
     /// the stream.
     async fn message_callback(&mut self, msg: CbResult<Message>) {
         let rcvd = match msg {
-            Ok(message) => format!("{:?}", message), // Leverage Debug for all Message variants
-            Err(error) => format!("Error: {}", error), // Handle WebSocket errors
+            Ok(message) => format!("{message:?}"), // Leverage Debug for all Message variants
+            Err(error) => format!("Error: {error}"), // Handle WebSocket errors
         };
 
         // Update the callback object's properties and log the message.
@@ -44,7 +44,7 @@ async fn main() {
         Err(err) => {
             println!("Could not load configuration file.");
             if config::exists("config.toml") {
-                println!("File exists, {}", err);
+                println!("File exists, {err}");
                 exit(1);
             }
 
@@ -61,7 +61,7 @@ async fn main() {
         .max_retries(20)
         .build()
         .map_err(|e| {
-            eprintln!("!ERROR! {}", e);
+            eprintln!("!ERROR! {e}");
             exit(1);
         })
         .unwrap();

--- a/src/apis/account.rs
+++ b/src/apis/account.rs
@@ -33,15 +33,23 @@ impl AccountApi {
     ///
     /// * `account_uuid` - A string the represents the account's UUID.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/accounts/{account_uuid}
-    ///
-    /// <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getaccount>
+    /// * <https://api.coinbase.com/api/v3/brokerage/accounts/{account_uuid>}
+    /// * <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getaccount>
     pub async fn get(&mut self, account_uuid: &str) -> CbResult<Account> {
         let agent = get_auth!(self.agent, "get account");
-        let resource = format!("{}/{}", RESOURCE_ENDPOINT, account_uuid);
+        let resource = format!("{RESOURCE_ENDPOINT}/{account_uuid}");
         let response = agent.get(&resource, &NoQuery).await?;
         let data: AccountWrapper = response
             .json()
@@ -55,13 +63,24 @@ impl AccountApi {
     /// account is found or there are not more accounts. This is a more expensive call, but more
     /// convient than `get` which requires knowing the UUID already.
     ///
-    /// NOTE: NOT A STANDARD API FUNCTION. QoL function that may require additional API requests than
+    /// NOTE: NOT A STANDARD API FUNCTION. QOL function that may require additional API requests than
     /// normal.
     ///
     /// # Arguments
     ///
     /// * `id` - Identifier for the account, such as BTC or ETH.
     /// * `query` - Parameters to control the query, such as limit.
+    ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    /// * `CbError::NotFound` - If the account was not found.
     pub async fn get_by_id(&mut self, id: &str, query: &AccountListQuery) -> CbResult<Account> {
         is_auth!(self.agent, "get account by ID");
 
@@ -79,8 +98,7 @@ impl AccountApi {
             // If no more pages to fetch, return a "not found" error with context.
             if !listed.has_next {
                 return Err(CbError::NotFound(format!(
-                    "No account found with ID '{}'.",
-                    id
+                    "No account found with ID '{id}'."
                 )));
             }
 
@@ -92,12 +110,22 @@ impl AccountApi {
     /// Obtains all accounts available to the API Key. Use a larger limit in the query to decrease
     /// the amount of API calls. Iteratively makes calls to obtain all accounts.
     ///
-    /// NOTE: NOT A STANDARD API FUNCTION. QoL function that may require additional API requests than
+    /// NOTE: NOT A STANDARD API FUNCTION. `QoL` function that may require additional API requests than
     /// normal.
     ///
     /// # Arguments
     ///
     /// * `query` - Parameters to control the query, such as limit.
+    ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
     pub async fn get_all(&mut self, query: &AccountListQuery) -> CbResult<Vec<Account>> {
         is_auth!(self.agent, "get all accounts");
 
@@ -126,12 +154,24 @@ impl AccountApi {
 
     /// Obtains various accounts from the API.
     ///
+    /// # Arguments
+    ///
+    /// * `query` - Parameters to control the query, such as limit.
+    ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/accounts
-    ///
-    /// <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getaccounts>
+    /// * <https://api.coinbase.com/api/v3/brokerage/accounts>
+    /// * <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getaccounts>
     pub async fn get_bulk(&mut self, query: &AccountListQuery) -> CbResult<PaginatedAccounts> {
         let agent = get_auth!(self.agent, "get bulk accounts");
         let response = agent.get(RESOURCE_ENDPOINT, query).await?;

--- a/src/apis/account.rs
+++ b/src/apis/account.rs
@@ -3,10 +3,10 @@
 //! `account` gives access to the Account API and the various endpoints associated with it.
 //! This allows you to obtain account information either by account UUID or in bulk (all accounts).
 
-use crate::account::{Account, AccountListQuery, AccountWrapper, PaginatedAccounts};
 use crate::constants::accounts::{LIST_ACCOUNT_MAXIMUM, RESOURCE_ENDPOINT};
 use crate::errors::CbError;
 use crate::http_agent::SecureHttpAgent;
+use crate::models::account::{Account, AccountListQuery, AccountWrapper, PaginatedAccounts};
 use crate::traits::{HttpAgent, NoQuery};
 use crate::types::CbResult;
 

--- a/src/apis/convert.rs
+++ b/src/apis/convert.rs
@@ -4,9 +4,9 @@
 //! This allows for the conversion between two currencies.
 
 use crate::constants::convert::{QUOTE_ENDPOINT, TRADE_ENDPOINT};
-use crate::convert::{ConvertQuery, ConvertQuoteRequest, Trade, TradeWrapper};
 use crate::errors::CbError;
 use crate::http_agent::SecureHttpAgent;
+use crate::models::convert::{ConvertQuery, ConvertQuoteRequest, Trade, TradeWrapper};
 use crate::traits::{HttpAgent, NoQuery};
 use crate::types::CbResult;
 

--- a/src/apis/convert.rs
+++ b/src/apis/convert.rs
@@ -29,7 +29,7 @@ impl ConvertApi {
     /// Create a convert quote with a specified source currency, target currency, and amount.
     ///
     /// Supported conversions are USD to USDC and USDC to USD - both with 0 fees.
-    /// Use the trade_id produced from this request to commit the trade.
+    /// Use the `trade_id` produced from this request to commit the trade.
     ///
     /// Trades are valid for 10 minutes after the quote is created.
     ///
@@ -37,12 +37,20 @@ impl ConvertApi {
     ///
     /// * `request` - The request to create a quote.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/convert/quote
-    ///
-    /// <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_createconvertquote>
+    /// * <https://api.coinbase.com/api/v3/brokerage/convert/quote>
+    /// * <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_createconvertquote>
     pub async fn create_quote(&mut self, request: &ConvertQuoteRequest) -> CbResult<Trade> {
         let agent = get_auth!(self.agent, "create convert quote");
         let response = agent.post(QUOTE_ENDPOINT, &NoQuery, request).await?;
@@ -60,15 +68,23 @@ impl ConvertApi {
     /// * `trade_id` - The trade ID to get information about.
     /// * `query` - The query to obtain the trade.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/convert/trade
-    ///
-    /// <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getconverttrade>
+    /// * <https://api.coinbase.com/api/v3/brokerage/convert/trade>
+    /// * <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getconverttrade>
     pub async fn get(&mut self, trade_id: &str, query: &ConvertQuery) -> CbResult<Trade> {
         let agent = get_auth!(self.agent, "get convert trade");
-        let resource = format!("{}/{}", TRADE_ENDPOINT, trade_id);
+        let resource = format!("{TRADE_ENDPOINT}/{trade_id}");
         let response = agent.get(&resource, query).await?;
         let data: TradeWrapper = response
             .json()
@@ -84,15 +100,23 @@ impl ConvertApi {
     /// * `trade_id` - The trade ID to get information about.
     /// * `query` - The query to commit the trade.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/convert/trade
-    ///
-    /// <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_commitconverttrade>
+    /// * <https://api.coinbase.com/api/v3/brokerage/convert/trade>
+    /// * <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_commitconverttrade>
     pub async fn commit(&mut self, trade_id: &str, query: &ConvertQuery) -> CbResult<Trade> {
         let agent = get_auth!(self.agent, "commit convert quote");
-        let resource = format!("{}/{}", TRADE_ENDPOINT, trade_id);
+        let resource = format!("{TRADE_ENDPOINT}/{trade_id}");
         let response = agent.post(&resource, &NoQuery, query).await?;
         let data: TradeWrapper = response
             .json()

--- a/src/apis/data.rs
+++ b/src/apis/data.rs
@@ -27,12 +27,20 @@ impl DataApi {
 
     /// Get information about your CDP API key permissions.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/key_permissions
-    ///
-    /// <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_getapikeypermissions>
+    /// * <https://api.coinbase.com/api/v3/brokerage/key_permissions>
+    /// * <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_getapikeypermissions>
     pub async fn key_permissions(&mut self) -> CbResult<KeyPermissions> {
         let agent = get_auth!(self.agent, "get key permissions");
         let response = agent.get(KEY_PERMISSIONS_ENDPOINT, &NoQuery).await?;

--- a/src/apis/fee.rs
+++ b/src/apis/fee.rs
@@ -32,12 +32,20 @@ impl FeeApi {
     ///
     /// * `query` - Paramaters used to modify the resulting scope of the summary.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/transaction_summary
-    ///
-    /// <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_gettransactionsummary>
+    /// * <https://api.coinbase.com/api/v3/brokerage/transaction_summary>
+    /// * <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_gettransactionsummary>
     pub async fn get(
         &mut self,
         query: &FeeTransactionSummaryQuery,

--- a/src/apis/fee.rs
+++ b/src/apis/fee.rs
@@ -5,8 +5,8 @@
 
 use crate::constants::fees::RESOURCE_ENDPOINT;
 use crate::errors::CbError;
-use crate::fee::{FeeTransactionSummaryQuery, TransactionSummary};
 use crate::http_agent::SecureHttpAgent;
+use crate::models::fee::{FeeTransactionSummaryQuery, TransactionSummary};
 use crate::traits::HttpAgent;
 use crate::types::CbResult;
 

--- a/src/apis/mod.rs
+++ b/src/apis/mod.rs
@@ -1,4 +1,4 @@
-//! # API Endpoints that are interact with via RestClient.
+//! # API Endpoints that are interact with via `RestClient`.
 //!
 //! This module contains all the API Endpoints that are used to interact with Coinbase Advanced.
 

--- a/src/apis/mod.rs
+++ b/src/apis/mod.rs
@@ -1,3 +1,7 @@
+//! # API Endpoints that are interact with via RestClient.
+//!
+//! This module contains all the API Endpoints that are used to interact with Coinbase Advanced.
+
 mod account;
 mod convert;
 mod data;
@@ -8,12 +12,12 @@ mod portfolio;
 mod product;
 mod public;
 
-pub(crate) use account::AccountApi;
-pub(crate) use convert::ConvertApi;
-pub(crate) use data::DataApi;
-pub(crate) use fee::FeeApi;
-pub(crate) use order::OrderApi;
-pub(crate) use payment::PaymentApi;
-pub(crate) use portfolio::PortfolioApi;
-pub(crate) use product::ProductApi;
-pub(crate) use public::PublicApi;
+pub use account::AccountApi;
+pub use convert::ConvertApi;
+pub use data::DataApi;
+pub use fee::FeeApi;
+pub use order::OrderApi;
+pub use payment::PaymentApi;
+pub use portfolio::PortfolioApi;
+pub use product::ProductApi;
+pub use public::PublicApi;

--- a/src/apis/order.rs
+++ b/src/apis/order.rs
@@ -9,7 +9,7 @@ use crate::constants::orders::{
 };
 use crate::errors::CbError;
 use crate::http_agent::SecureHttpAgent;
-use crate::order::{
+use crate::models::order::{
     Order, OrderCancelRequest, OrderCancelResponse, OrderCancelWrapper, OrderClosePositionRequest,
     OrderCreatePreview, OrderCreateRequest, OrderCreateResponse, OrderEditPreview,
     OrderEditRequest, OrderEditResponse, OrderListFillsQuery, OrderListQuery, OrderStatus,

--- a/src/apis/order.rs
+++ b/src/apis/order.rs
@@ -40,12 +40,20 @@ impl OrderApi {
     ///
     /// * `request` - A struct containing what orders to cancel.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/orders/batch_cancel
-    ///
-    /// <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_cancelorders>
+    /// * <https://api.coinbase.com/api/v3/brokerage/orders/batch_cancel>
+    /// * <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_cancelorders>
     pub async fn cancel(
         &mut self,
         request: &OrderCancelRequest,
@@ -61,12 +69,22 @@ impl OrderApi {
 
     /// Cancel all OPEN orders for a specific product ID.
     ///
-    /// NOTE: NOT A STANDARD API FUNCTION. QoL function that may require additional API requests
+    /// NOTE: NOT A STANDARD API FUNCTION. QOL function that may require additional API requests
     /// than normal.
     ///
     /// # Arguments
     ///
     /// * `product_id` - Product to cancel all OPEN orders for.
+    ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
     pub async fn cancel_all(&mut self, product_id: &str) -> CbResult<Vec<OrderCancelResponse>> {
         is_auth!(self.agent, "cancel all orders");
 
@@ -105,12 +123,20 @@ impl OrderApi {
     ///
     /// * `request` - A struct containing the order ID, new size, and new price.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/orders/edit
-    ///
-    /// https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_editorder
+    /// * <https://api.coinbase.com/api/v3/brokerage/orders/edit>
+    /// * <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_editorder>
     pub async fn edit(&mut self, request: &OrderEditRequest) -> CbResult<OrderEditResponse> {
         let agent = get_auth!(self.agent, "edit order");
         let response = agent.post(EDIT_ENDPOINT, &NoQuery, request).await?;
@@ -127,12 +153,20 @@ impl OrderApi {
     ///
     /// * `request` - A struct containing the order details to preview.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/orders/preview
-    ///
-    /// <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_previeworder>
+    /// * <https://api.coinbase.com/api/v3/brokerage/orders/preview>
+    /// * <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_previeworder>
     pub async fn preview_create(
         &mut self,
         request: &OrderCreateRequest,
@@ -155,12 +189,20 @@ impl OrderApi {
     ///
     /// * `request` - A struct containing the order ID, new size, and new price.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/orders/edit_preivew
-    ///
-    /// https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_previeweditorder
+    /// * <https://api.coinbase.com/api/v3/brokerage/orders/edit_preivew>
+    /// * <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_previeweditorder>
     pub async fn preview_edit(&mut self, request: &OrderEditRequest) -> CbResult<OrderEditPreview> {
         let agent = get_auth!(self.agent, "preview edit order");
         let response = agent.post(EDIT_PREVIEW_ENDPOINT, &NoQuery, request).await?;
@@ -177,12 +219,20 @@ impl OrderApi {
     ///
     /// * `request` - A struct containing the order details to create.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/orders
-    ///
-    /// <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_postorder>
+    /// * <https://api.coinbase.com/api/v3/brokerage/orders>
+    /// * <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_postorder>
     pub async fn create(&mut self, request: &OrderCreateRequest) -> CbResult<OrderCreateResponse> {
         let agent = get_auth!(self.agent, "create order");
         let response = agent.post(RESOURCE_ENDPOINT, &NoQuery, request).await?;
@@ -199,15 +249,23 @@ impl OrderApi {
     ///
     /// * `order_id` - A string that represents the order's ID.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/orders/historical/{order_id}
-    ///
-    /// <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_gethistoricalorder>
+    /// * <https://api.coinbase.com/api/v3/brokerage/orders/historical/{order_id>}
+    /// * <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_gethistoricalorder>
     pub async fn get(&mut self, order_id: &str) -> CbResult<Order> {
         let agent = get_auth!(self.agent, "get order");
-        let resource = format!("{}/historical/{}", RESOURCE_ENDPOINT, order_id);
+        let resource = format!("{RESOURCE_ENDPOINT}/historical/{order_id}");
         let response = agent.get(&resource, &NoQuery).await?;
         let data: OrderWrapper = response
             .json()
@@ -222,12 +280,20 @@ impl OrderApi {
     ///
     /// * `query` - A Parameters to modify what is returned by the API.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/orders/historical
-    ///
-    /// <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_gethistoricalorders>
+    /// * <https://api.coinbase.com/api/v3/brokerage/orders/historical>
+    /// * <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_gethistoricalorders>
     pub async fn get_bulk(&mut self, query: &OrderListQuery) -> CbResult<PaginatedOrders> {
         let agent = get_auth!(self.agent, "get bulk orders");
         let response = agent.get(BATCH_ENDPOINT, query).await?;
@@ -242,12 +308,22 @@ impl OrderApi {
     /// This wraps `get_bulk` and makes several additional requests until there are no
     /// additional orders.
     ///
-    /// NOTE: NOT A STANDARD API FUNCTION. QoL function that may require additional API requests than normal.
+    /// NOTE: NOT A STANDARD API FUNCTION. QOL function that may require additional API requests than normal.
     ///
     /// # Arguments
     ///
     /// * `product_id` - Identifier for the account, such as BTC-USD or ETH-USD.
     /// * `query` - A Parameters to modify what is returned by the API.
+    ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
     pub async fn get_all(
         &mut self,
         product_id: &str,
@@ -280,12 +356,20 @@ impl OrderApi {
     ///
     /// * `query` - A Parameters to modify what is returned by the API.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/orders/historical/fills
-    ///
-    /// <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getfills>
+    /// * <https://api.coinbase.com/api/v3/brokerage/orders/historical/fills>
+    /// * <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getfills>
     pub async fn fills(&mut self, query: &OrderListFillsQuery) -> CbResult<PaginatedFills> {
         let agent = get_auth!(self.agent, "get fills");
         let response = agent.get(FILLS_ENDPOINT, query).await?;
@@ -296,18 +380,26 @@ impl OrderApi {
         Ok(data)
     }
 
-    /// Places an order to close any open positions for a specified product_id.
+    /// Places an order to close any open positions for a specified `product_id`.
     ///
     /// # Arguments
     ///
     /// * `request` - A request as to what position to close.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/orders/close_position
-    ///
-    /// <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_closeposition>
+    /// * <https://api.coinbase.com/api/v3/brokerage/orders/close_position>
+    /// * <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_closeposition>
     pub async fn close_position(
         &mut self,
         request: &OrderClosePositionRequest,

--- a/src/apis/payment.rs
+++ b/src/apis/payment.rs
@@ -27,12 +27,20 @@ impl PaymentApi {
 
     /// Obtains a list of payment methods for the current user from the API.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/payment_methods
-    ///
-    /// <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_getpaymentmethods>
+    /// * <https://api.coinbase.com/api/v3/brokerage/payment_methods>
+    /// * <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_getpaymentmethods>
     pub async fn get_all(&mut self) -> CbResult<Vec<PaymentMethod>> {
         let agent = get_auth!(self.agent, "get all payment methods");
         let response = agent.get(RESOURCE_ENDPOINT, &NoQuery).await?;
@@ -49,15 +57,23 @@ impl PaymentApi {
     ///
     /// * `payment_method_id` - The unique identifier for the payment method.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/payment_methods
-    ///
-    /// <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_getpaymentmethod>
+    /// * <https://api.coinbase.com/api/v3/brokerage/payment_methods>
+    /// * <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_getpaymentmethod>
     pub async fn get(&mut self, payment_method_id: &str) -> CbResult<PaymentMethod> {
         let agent = get_auth!(self.agent, "get payment method");
-        let resource = format!("{}/{}", RESOURCE_ENDPOINT, payment_method_id);
+        let resource = format!("{RESOURCE_ENDPOINT}/{payment_method_id}");
         let response = agent.get(&resource, &NoQuery).await?;
         let data: PaymentMethodWrapper = response
             .json()

--- a/src/apis/portfolio.rs
+++ b/src/apis/portfolio.rs
@@ -36,12 +36,20 @@ impl PortfolioApi {
     ///
     /// * `query` - The query parameters to filter the results.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/portfolios
-    ///
-    /// <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_getportfolios>
+    /// * <https://api.coinbase.com/api/v3/brokerage/portfolios>
+    /// * <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_getportfolios>
     pub async fn get_all(&mut self, query: &PortfolioListQuery) -> CbResult<Vec<Portfolio>> {
         let agent = get_auth!(self.agent, "get all portfolios");
         let response = agent.get(RESOURCE_ENDPOINT, query).await?;
@@ -58,12 +66,20 @@ impl PortfolioApi {
     ///
     /// * `request` - The request to create a new portfolio.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/portfolios
-    ///
-    /// <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_createportfolio>
+    /// * <https://api.coinbase.com/api/v3/brokerage/portfolios>
+    /// * <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_createportfolio>
     pub async fn create(&mut self, request: &PortfolioModifyRequest) -> CbResult<Portfolio> {
         let agent = get_auth!(self.agent, "create portfolio");
         let response = agent.post(RESOURCE_ENDPOINT, &NoQuery, request).await?;
@@ -81,19 +97,27 @@ impl PortfolioApi {
     /// * `portfolio_uuid` - The UUID of the portfolio to edit.
     /// * `request` - The request to edit the portfolio.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/portfolios
-    ///
-    /// <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_editportfolio>
+    /// * <https://api.coinbase.com/api/v3/brokerage/portfolios>
+    /// * <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_editportfolio>
     pub async fn edit(
         &mut self,
         portfolio_uuid: &str,
         request: &PortfolioModifyRequest,
     ) -> CbResult<Portfolio> {
         let agent = get_auth!(self.agent, "edit portfolio");
-        let resource = format!("{}/{}", RESOURCE_ENDPOINT, portfolio_uuid);
+        let resource = format!("{RESOURCE_ENDPOINT}/{portfolio_uuid}");
         let response = agent.put(&resource, &NoQuery, request).await?;
         let data: PortfolioWrapper = response
             .json()
@@ -108,15 +132,22 @@ impl PortfolioApi {
     ///
     /// * `portfolio_uuid` - The UUID of the portfolio to delete.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/portfolios
-    ///
-    /// <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_editportfolio>
+    /// * <https://api.coinbase.com/api/v3/brokerage/portfolios>
+    /// * <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_editportfolio>
     pub async fn delete(&mut self, portfolio_uuid: &str) -> CbResult<()> {
         let agent = get_auth!(self.agent, "delete portfolio");
-        let resource = format!("{}/{}", RESOURCE_ENDPOINT, portfolio_uuid);
+        let resource = format!("{RESOURCE_ENDPOINT}/{portfolio_uuid}");
         agent.delete(&resource, &NoQuery).await?;
         Ok(())
     }
@@ -127,12 +158,19 @@ impl PortfolioApi {
     ///
     /// * `request` - The request to move funds.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/portfolios/move_funds
-    ///
-    /// <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_moveportfoliofunds>
+    /// * <https://api.coinbase.com/api/v3/brokerage/portfolios/move_funds>
+    /// * <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_moveportfoliofunds>
     pub async fn move_funds(&mut self, request: &PortfolioMoveFundsRequest) -> CbResult<()> {
         let agent = get_auth!(self.agent, "move funds");
         agent.post(MOVE_FUNDS_ENDPOINT, &NoQuery, request).await?;
@@ -146,19 +184,27 @@ impl PortfolioApi {
     /// * `portfolio_uuid` - The UUID of the portfolio to obtain a breakdown for.
     /// * `query` - The query parameters to filter the results.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/portfolios
-    ///
-    /// <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_getportfoliobreakdown>
+    /// * <https://api.coinbase.com/api/v3/brokerage/portfolios>
+    /// * <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_getportfoliobreakdown>
     pub async fn get(
         &mut self,
         portfolio_uuid: &str,
         query: &PortfolioBreakdownQuery,
     ) -> CbResult<PortfolioBreakdown> {
         let agent = get_auth!(self.agent, "get portfolio breakdown");
-        let resource = format!("{}/{}", RESOURCE_ENDPOINT, portfolio_uuid);
+        let resource = format!("{RESOURCE_ENDPOINT}/{portfolio_uuid}");
         let response = agent.get(&resource, query).await?;
         let data: PortfolioBreakdownWrapper = response
             .json()

--- a/src/apis/portfolio.rs
+++ b/src/apis/portfolio.rs
@@ -6,10 +6,10 @@
 use crate::constants::portfolios::{MOVE_FUNDS_ENDPOINT, RESOURCE_ENDPOINT};
 use crate::errors::CbError;
 use crate::http_agent::SecureHttpAgent;
-use crate::models::portfolio::{Portfolio, PortfolioListQuery, PortfoliosWrapper};
-use crate::portfolio::{
-    PortfolioBreakdown, PortfolioBreakdownQuery, PortfolioBreakdownWrapper, PortfolioModifyRequest,
-    PortfolioMoveFundsRequest, PortfolioWrapper,
+use crate::models::portfolio::{
+    Portfolio, PortfolioBreakdown, PortfolioBreakdownQuery, PortfolioBreakdownWrapper,
+    PortfolioListQuery, PortfolioModifyRequest, PortfolioMoveFundsRequest, PortfolioWrapper,
+    PortfoliosWrapper,
 };
 use crate::traits::{HttpAgent, NoQuery};
 use crate::types::CbResult;

--- a/src/apis/product.rs
+++ b/src/apis/product.rs
@@ -40,12 +40,20 @@ impl ProductApi {
     ///
     /// * `query` - A query to obtain the best bid/ask for multiple products.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/best_bid_ask
-    ///
-    /// <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getbestbidask>
+    /// * <https://api.coinbase.com/api/v3/brokerage/best_bid_ask>
+    /// * <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getbestbidask>
     pub async fn best_bid_ask(&mut self, query: &ProductBidAskQuery) -> CbResult<Vec<ProductBook>> {
         let agent = get_auth!(self.agent, "get best bid/ask");
         let response = agent.get(BID_ASK_ENDPOINT, query).await?;
@@ -62,12 +70,20 @@ impl ProductApi {
     ///
     /// * `query` - A query to obtain the product book.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/product_book
-    ///
-    /// <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getproductbook>
+    /// * <https://api.coinbase.com/api/v3/brokerage/product_book>
+    /// * <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getproductbook>
     pub async fn product_book(&mut self, query: &ProductBookQuery) -> CbResult<ProductBook> {
         let agent = get_auth!(self.agent, "get product book");
         let response = agent.get(PRODUCT_BOOK_ENDPOINT, query).await?;
@@ -84,15 +100,23 @@ impl ProductApi {
     ///
     /// * `product_id` - A string the represents the product's ID.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/products/{product_id}
-    ///
-    /// <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getproduct>
+    /// * <https://api.coinbase.com/api/v3/brokerage/products/{product_id>}
+    /// * <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getproduct>
     pub async fn get(&mut self, product_id: &str) -> CbResult<Product> {
         let agent = get_auth!(self.agent, "get product");
-        let resource = format!("{}/{}", RESOURCE_ENDPOINT, product_id);
+        let resource = format!("{RESOURCE_ENDPOINT}/{product_id}");
         let response = agent.get(&resource, &NoQuery).await?;
         let data: Product = response
             .json()
@@ -107,12 +131,20 @@ impl ProductApi {
     ///
     /// * `query` - Query used to obtain products.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/products
-    ///
-    /// <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getproducts>
+    /// * <https://api.coinbase.com/api/v3/brokerage/products>
+    /// * <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getproducts>
     pub async fn get_bulk(&mut self, query: &ProductListQuery) -> CbResult<Vec<Product>> {
         let agent = get_auth!(self.agent, "get bulk products");
         let response = agent.get(RESOURCE_ENDPOINT, query).await?;
@@ -130,19 +162,27 @@ impl ProductApi {
     /// * `product_id` - A string the represents the product's ID.
     /// * `query` - A query to obtain candles within a span of time.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/products/{product_id}/candles
-    ///
-    /// <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getcandles>
+    /// * <https://api.coinbase.com/api/v3/brokerage/products/{product_id}/candles>
+    /// * <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getcandles>
     pub async fn candles(
         &mut self,
         product_id: &str,
         query: &ProductCandleQuery,
     ) -> CbResult<Vec<Candle>> {
         let agent = get_auth!(self.agent, "get candles");
-        let resource = format!("{}/{}/candles", RESOURCE_ENDPOINT, product_id);
+        let resource = format!("{RESOURCE_ENDPOINT}/{product_id}/candles");
         let response = agent.get(&resource, query).await?;
         let data: CandlesWrapper = response
             .json()
@@ -154,13 +194,23 @@ impl ProductApi {
     /// Obtains candles for a specific product extended. This will exceed the 300 limit threshold
     /// and try to obtain the amount specified.
     ///
-    /// NOTE: NOT A STANDARD API FUNCTION. QoL function that may require additional API requests than
+    /// NOTE: NOT A STANDARD API FUNCTION. QOL function that may require additional API requests than
     /// normal.
     ///
     /// # Arguments
     ///
     /// * `product_id` - A string the represents the product's ID.
     /// * `query` - Span of time to obtain.
+    ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
     pub async fn candles_ext(
         &mut self,
         product_id: &str,
@@ -172,8 +222,8 @@ impl ProductApi {
         // Extract query parameters.
         let end_time = query.end;
         let granularity = query.granularity.clone();
-        let interval_seconds = Granularity::to_secs(&granularity) as u64;
-        let maximum_candles = CANDLE_MAXIMUM as u64;
+        let interval_seconds = u64::from(Granularity::to_secs(&granularity));
+        let maximum_candles = u64::from(CANDLE_MAXIMUM);
 
         // Initialize the span.
         let mut current_start = query.start;
@@ -211,19 +261,27 @@ impl ProductApi {
     /// * `product_id` - A string the represents the product's ID.
     /// * `query` - Amount of products to get.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::AuthenticationError` - If the agent is not authenticated.
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    /// * `CbError::BadJwt` - If there was an issue creating the JWT.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/products/{product_id}/ticker
-    ///
-    /// <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getmarkettrades>
+    /// * <https://api.coinbase.com/api/v3/brokerage/products/{product_id}/ticker>
+    /// * <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getmarkettrades>
     pub async fn ticker(
         &mut self,
         product_id: &str,
         query: &ProductTickerQuery,
     ) -> CbResult<Ticker> {
         let agent = get_auth!(self.agent, "get ticker");
-        let resource = format!("{}/{}/ticker", RESOURCE_ENDPOINT, product_id);
+        let resource = format!("{RESOURCE_ENDPOINT}/{product_id}/ticker");
         let response = agent.get(&resource, query).await?;
         let data: Ticker = response
             .json()

--- a/src/apis/product.rs
+++ b/src/apis/product.rs
@@ -10,10 +10,10 @@ use crate::constants::products::{
 use crate::errors::CbError;
 use crate::http_agent::SecureHttpAgent;
 use crate::models::product::{
-    Candle, CandlesWrapper, Product, ProductBook, ProductBookWrapper, ProductBooksWrapper,
-    ProductListQuery, ProductTickerQuery, ProductsWrapper, Ticker,
+    Candle, CandlesWrapper, Product, ProductBidAskQuery, ProductBook, ProductBookQuery,
+    ProductBookWrapper, ProductBooksWrapper, ProductCandleQuery, ProductListQuery,
+    ProductTickerQuery, ProductsWrapper, Ticker,
 };
-use crate::product::{ProductBidAskQuery, ProductBookQuery, ProductCandleQuery};
 use crate::time::{self, Granularity};
 use crate::traits::{HttpAgent, NoQuery, Query};
 use crate::types::CbResult;

--- a/src/apis/public.rs
+++ b/src/apis/public.rs
@@ -35,12 +35,18 @@ impl PublicApi {
 
     /// Get the current time from the Coinbase Advanced API.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/time
-    ///
-    /// <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_getservertime>
+    /// * <https://api.coinbase.com/api/v3/brokerage/time>
+    /// * <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_getservertime>
     pub async fn time(&mut self) -> CbResult<ServerTime> {
         let response = self.agent.get(SERVERTIME_ENDPOINT, &NoQuery).await?;
         let data: ServerTime = response
@@ -56,12 +62,18 @@ impl PublicApi {
     ///
     /// * `query` - Query used to obtain the product book.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/market/product_book
-    ///
-    /// <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_getpublicproductbook>
+    /// * <https://api.coinbase.com/api/v3/brokerage/market/product_book>
+    /// * <https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_getpublicproductbook>
     pub async fn product_book(&mut self, query: &ProductBookQuery) -> CbResult<ProductBook> {
         let response = self.agent.get(PRODUCT_BOOK_ENDPOINT, query).await?;
         let data: ProductBookWrapper = response
@@ -77,14 +89,20 @@ impl PublicApi {
     ///
     /// * `product_id` - A string the represents the product's ID.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/products/{product_id}
-    ///
-    /// <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getproduct>
+    /// * <https://api.coinbase.com/api/v3/brokerage/products/{product_id>}
+    /// * <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getproduct>
     pub async fn product(&mut self, product_id: &str) -> CbResult<Product> {
-        let resource = format!("{}/{}", RESOURCE_ENDPOINT, product_id);
+        let resource = format!("{RESOURCE_ENDPOINT}/{product_id}");
         let response = self.agent.get(&resource, &NoQuery).await?;
         let data: Product = response
             .json()
@@ -99,12 +117,18 @@ impl PublicApi {
     ///
     /// * `query` - Query used to obtain products.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/products
-    ///
-    /// <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getproducts>
+    /// * <https://api.coinbase.com/api/v3/brokerage/products>
+    /// * <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getproducts>
     pub async fn products(&mut self, query: &ProductListQuery) -> CbResult<Vec<Product>> {
         let response = self.agent.get(RESOURCE_ENDPOINT, query).await?;
         let data: ProductsWrapper = response
@@ -121,18 +145,24 @@ impl PublicApi {
     /// * `product_id` - A string the represents the product's ID.
     /// * `query` - Span of time to obtain.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/products/{product_id}/candles
-    ///
-    /// <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getcandles>
+    /// * <https://api.coinbase.com/api/v3/brokerage/products/{product_id}/candles>
+    /// * <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getcandles>
     pub async fn candles(
         &mut self,
         product_id: &str,
         query: &ProductCandleQuery,
     ) -> CbResult<Vec<Candle>> {
-        let resource = format!("{}/{}/candles", RESOURCE_ENDPOINT, product_id);
+        let resource = format!("{RESOURCE_ENDPOINT}/{product_id}/candles");
         let response = self.agent.get(&resource, query).await?;
         let data: CandlesWrapper = response
             .json()
@@ -144,13 +174,21 @@ impl PublicApi {
     /// Obtains candles for a specific product extended. This will exceed the 300 limit threshold
     /// and try to obtain the amount specified.
     ///
-    /// NOTE: NOT A STANDARD API FUNCTION. QoL function that may require additional API requests than
+    /// NOTE: NOT A STANDARD API FUNCTION. QOL function that may require additional API requests than
     /// normal.
     ///
     /// # Arguments
     ///
     /// * `product_id` - A string the represents the product's ID.
     /// * `query` - Span of time to obtain.
+    ///
+    /// # Errors
+    ///
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
     pub async fn candles_ext(
         &mut self,
         product_id: &str,
@@ -161,8 +199,8 @@ impl PublicApi {
         // Extract query parameters.
         let end_time = query.end;
         let granularity = query.granularity.clone();
-        let interval_seconds = Granularity::to_secs(&granularity) as u64;
-        let maximum_candles = CANDLE_MAXIMUM as u64;
+        let interval_seconds = u64::from(Granularity::to_secs(&granularity));
+        let maximum_candles = u64::from(CANDLE_MAXIMUM);
 
         // Initialize the span.
         let mut current_start = query.start;
@@ -200,18 +238,24 @@ impl PublicApi {
     /// * `product_id` - A string the represents the product's ID.
     /// * `query` - Amount of products to get.
     ///
+    /// # Errors
+    ///
+    /// * `CbError::JsonError` - If there was an issue parsing the JSON response.
+    /// * `CbError::RequestError` - If there was an issue making the request.
+    /// * `CbError::UrlParseError` - If there was an issue parsing the URL.
+    /// * `CbError::BadSerialization` - If there was an issue serializing the request.
+    /// * `CbError::BadStatus` - If the status code was not 200.
+    ///
     /// # Endpoint / Reference
     ///
-    #[allow(rustdoc::bare_urls)]
-    /// https://api.coinbase.com/api/v3/brokerage/products/{product_id}/ticker
-    ///
-    /// <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getmarkettrades>
+    /// * <https://api.coinbase.com/api/v3/brokerage/products/{product_id}/ticker>
+    /// * <https://docs.cloud.coinbase.com/advanced-trade-api/reference/retailbrokerageapi_getmarkettrades>
     pub async fn ticker(
         &mut self,
         product_id: &str,
         query: &ProductTickerQuery,
     ) -> CbResult<Ticker> {
-        let resource = format!("{}/{}/ticker", RESOURCE_ENDPOINT, product_id);
+        let resource = format!("{RESOURCE_ENDPOINT}/{product_id}/ticker");
         let response = self.agent.get(&resource, query).await?;
         let data: Ticker = response
             .json()

--- a/src/apis/public.rs
+++ b/src/apis/public.rs
@@ -11,8 +11,8 @@ use crate::models::product::{
     Candle, CandlesWrapper, Product, ProductBook, ProductBookWrapper, ProductListQuery,
     ProductTickerQuery, ProductsWrapper, Ticker,
 };
+use crate::models::product::{ProductBookQuery, ProductCandleQuery};
 use crate::models::public::ServerTime;
-use crate::product::{ProductBookQuery, ProductCandleQuery};
 use crate::time::{self, Granularity};
 use crate::traits::{HttpAgent, NoQuery, Query};
 use crate::types::CbResult;

--- a/src/candle_watcher.rs
+++ b/src/candle_watcher.rs
@@ -1,6 +1,5 @@
 //! Candle Watcher is the underlying object used to track candle updates.
 
-use std::cmp::Ord;
 use std::collections::HashMap;
 
 use async_trait::async_trait;
@@ -8,10 +7,9 @@ use chrono::Utc;
 
 use crate::constants::websocket::GRANULARITY;
 use crate::models::product::Candle;
-use crate::models::websocket::{CandleUpdate, Channel, Event, Message};
+use crate::models::websocket::{CandleUpdate, Channel, Endpoint, Event, Message};
 use crate::traits::{CandleCallback, MessageCallback};
 use crate::types::CbResult;
-use crate::ws::Endpoint;
 use crate::WebSocketClient;
 
 /// Tracks the candle watcher task.

--- a/src/candle_watcher.rs
+++ b/src/candle_watcher.rs
@@ -3,6 +3,7 @@
 use std::cmp::Ord;
 use std::collections::HashMap;
 
+use async_trait::async_trait;
 use chrono::Utc;
 
 use crate::constants::websocket::GRANULARITY;
@@ -44,7 +45,7 @@ where
         };
 
         // Start the listener.
-        client.listen_trait(endpoint, tracker).await;
+        client.listen(endpoint, tracker).await;
     }
 
     /// Returns a completed candle if a newer candle is received.
@@ -135,12 +136,13 @@ where
     }
 }
 
+#[async_trait]
 impl<T> MessageCallback for CandleWatcher<T>
 where
     T: CandleCallback + Send + Sync,
 {
     /// Handles incoming messages and processes candle updates.
-    fn message_callback(&mut self, msg: CbResult<Message>) {
+    async fn message_callback(&mut self, msg: CbResult<Message>) {
         match msg {
             Ok(message) => {
                 if message.channel != Channel::Candles {

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,7 @@ pub trait ConfigFile {
 }
 
 /// Configuration settings for API, this should be in either a custom user configuration or
-/// in the BaseConfig. See `BaseConfig` or `config.toml.sample` for
+/// in the `BaseConfig`. See `BaseConfig` or `config.toml.sample` for
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ApiConfig {
     /// Version of the Configuration file.
@@ -84,6 +84,14 @@ pub fn new() -> ApiConfig {
 /// # Arguments
 ///
 /// * `path` - A string slice that holds the location for the file.
+///
+/// # Panics
+///
+/// Panics if the file cannot be written.
+///
+/// # Errors
+///
+/// Errors if the file cannot be written.
 pub fn create_base_config(path: &str) -> Result<(), std::io::Error> {
     let contents = toml::to_string_pretty(&BaseConfig::default());
     fs::write(path, contents.unwrap())
@@ -93,8 +101,16 @@ pub fn create_base_config(path: &str) -> Result<(), std::io::Error> {
 ///
 /// # Arguments
 ///
-/// * `config` - Configuration that implement ConfigFile trait.
+/// * `config` - Configuration that implement `ConfigFile` trait.
 /// * `path` - A string slice that holds the location for the file.
+///
+/// # Panics
+///
+/// Panics if the file cannot be written.
+///
+/// # Errors
+///
+/// Errors if the file cannot be written.
 pub fn save<T>(config: &T, path: &str) -> Result<(), std::io::Error>
 where
     T: ConfigFile + Serialize,
@@ -108,6 +124,10 @@ where
 /// # Arguments
 ///
 /// * `path` - A string slice that holds the location for the file.
+///
+/// # Errors
+///
+/// Errors if the file cannot be read or the configuration cannot be parsed.
 pub fn load<T>(path: &str) -> Result<T, &str>
 where
     T: ConfigFile + DeserializeOwned,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -71,7 +71,7 @@ pub(crate) mod websocket {
     pub(crate) const SECURE_ENDPOINT: &str = "wss://advanced-trade-ws-user.coinbase.com";
 
     /// Granularity of Candles from the WebSocket Candle subscription.
-    /// NOTE: This is a restriction by CoinBase and cannot be currently changed (20240125)
+    /// NOTE: This is a restriction by `CoinBase` and cannot be currently changed (20240125)
     pub(crate) const GRANULARITY: u64 = 300;
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -19,6 +19,8 @@ pub enum CbError {
     NothingToDo(String),
     /// Unable to locate resource.
     NotFound(String),
+    /// JWT generation error.
+    BadJwt(String),
     /// Could not build the signature.
     BadSignature(String),
     /// Could not identify the API Secret key type.
@@ -44,25 +46,26 @@ pub enum CbError {
 impl fmt::Display for CbError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            CbError::Unknown(value) => write!(f, "unknown error occurred: {}", value),
-            CbError::BadSignature(value) => write!(f, "could not create signature: {}", value),
+            CbError::Unknown(value) => write!(f, "unknown error occurred: {value}"),
+            CbError::BadJwt(value) => write!(f, "could not create JWT: {value}"),
+            CbError::BadSignature(value) => write!(f, "could not create signature: {value}"),
             CbError::BadSerialization(value) => {
-                write!(f, "could not serialize the message body: {}", value)
+                write!(f, "could not serialize the message body: {value}")
             }
-            CbError::BadPrivateKey(value) => write!(f, "invalid private key: {}", value),
-            CbError::BadParse(value) => write!(f, "could not parse: {}", value),
-            CbError::NothingToDo(value) => write!(f, "nothing to do: {}", value),
-            CbError::NotFound(value) => write!(f, "could not find: {}", value),
+            CbError::BadPrivateKey(value) => write!(f, "invalid private key: {value}"),
+            CbError::BadParse(value) => write!(f, "could not parse: {value}"),
+            CbError::NothingToDo(value) => write!(f, "nothing to do: {value}"),
+            CbError::NotFound(value) => write!(f, "could not find: {value}"),
             CbError::BadStatus { code, body } => {
                 write!(f, "HTTP error {}: {}", code.as_u16(), body)
             }
-            CbError::BadConnection(value) => write!(f, "could not connect: {}", value),
-            CbError::RequestError(value) => write!(f, "HTTP request error: {}", value),
-            CbError::UrlParseError(value) => write!(f, "URL parse error: {}", value),
-            CbError::JsonError(value) => write!(f, "JSON deserialization error: {}", value),
-            CbError::AuthenticationError(value) => write!(f, "authentication error: {}", value),
-            CbError::BadQuery(value) => write!(f, "invalid query: {}", value),
-            CbError::BadRequest(value) => write!(f, "invalid request: {}", value),
+            CbError::BadConnection(value) => write!(f, "could not connect: {value}"),
+            CbError::RequestError(value) => write!(f, "HTTP request error: {value}"),
+            CbError::UrlParseError(value) => write!(f, "URL parse error: {value}"),
+            CbError::JsonError(value) => write!(f, "JSON deserialization error: {value}"),
+            CbError::AuthenticationError(value) => write!(f, "authentication error: {value}"),
+            CbError::BadQuery(value) => write!(f, "invalid query: {value}"),
+            CbError::BadRequest(value) => write!(f, "invalid request: {value}"),
         }
     }
 }

--- a/src/http_agent.rs
+++ b/src/http_agent.rs
@@ -1,7 +1,7 @@
 //! # Authentication and signing messages.
 //!
-//! `http_agent` contains the backbone of the API requests in the form of the SecureHttpAgent and PublicHttpAgent struct. This signs
-//! all requests to the API for ensure proper authentication. The HttpAgents are also responsible for handling
+//! `http_agent` contains the backbone of the API requests in the form of the `SecureHttpAgent` and `PublicHttpAgent` struct. This signs
+//! all requests to the API for ensure proper authentication. The `HttpAgents` are also responsible for handling
 //! the GET and POST requests.
 
 use std::sync::Arc;
@@ -30,7 +30,7 @@ pub(crate) struct HttpAgentBase {
 }
 
 impl HttpAgentBase {
-    /// Creates a new instance of SecureHttpAgent.
+    /// Creates a new instance of `SecureHttpAgent`.
     ///
     /// # Arguments
     ///
@@ -79,7 +79,7 @@ impl HttpAgentBase {
     /// # Arguments
     ///
     /// * `request` - The request to convert to a JSON string.
-    fn convert_request<'a, T>(&self, request: &'a T) -> CbResult<String>
+    fn convert_request<'a, T>(request: &'a T) -> CbResult<String>
     where
         T: Request + Serialize + 'a,
     {
@@ -158,7 +158,7 @@ pub(crate) struct PublicHttpAgent {
 }
 
 impl PublicHttpAgent {
-    /// Creates a new instance of PublicHttpAgent.
+    /// Creates a new instance of `PublicHttpAgent`.
     ///
     /// # Arguments
     ///
@@ -189,7 +189,7 @@ impl HttpAgent for PublicHttpAgent {
         T: Request + Serialize + 'a,
     {
         let url = self.base.build_url(resource, query)?;
-        let data = self.base.convert_request(body)?;
+        let data = HttpAgentBase::convert_request(body)?;
         self.base
             .execute_request(Method::POST, url, Some(data), None)
             .await
@@ -205,7 +205,7 @@ impl HttpAgent for PublicHttpAgent {
         T: Request + Serialize + 'a,
     {
         let url = self.base.build_url(resource, query)?;
-        let data = self.base.convert_request(body)?;
+        let data = HttpAgentBase::convert_request(body)?;
         self.base
             .execute_request(Method::PUT, url, Some(data), None)
             .await
@@ -230,7 +230,7 @@ pub(crate) struct SecureHttpAgent {
 
 /// Responsible for signing and sending HTTP requests.
 impl SecureHttpAgent {
-    /// Creates a new instance of SecureHttpAgent.
+    /// Creates a new instance of `SecureHttpAgent`.
     ///
     /// # Arguments
     ///
@@ -250,7 +250,7 @@ impl SecureHttpAgent {
         } else {
             Some(
                 Jwt::new(api_key, api_secret)
-                    .map_err(|e| CbError::Unknown(format!("Error creating JWT: {}", e)))?,
+                    .map_err(|e| CbError::BadJwt(format!("Error creating JWT: {e}")))?,
             )
         };
 
@@ -266,7 +266,7 @@ impl SecureHttpAgent {
     ///
     /// * `method` - The method of the request, GET, POST, etc.
     /// * `resource` - The resource being accessed.
-    fn build_token(&self, method: Method, resource: &str) -> CbResult<Option<String>> {
+    fn build_token(&self, method: &Method, resource: &str) -> CbResult<Option<String>> {
         if let Some(jwt) = &self.jwt {
             let uri = Jwt::build_uri(method.as_str(), self.base.root_uri, resource);
             Ok(Some(jwt.encode(Some(&uri))?))
@@ -279,7 +279,7 @@ impl SecureHttpAgent {
 impl HttpAgent for SecureHttpAgent {
     async fn get(&mut self, resource: &str, query: &impl Query) -> CbResult<Response> {
         let url = self.base.build_url(resource, query)?;
-        let token = self.build_token(Method::GET, resource)?;
+        let token = self.build_token(&Method::GET, resource)?;
         self.base
             .execute_request(Method::GET, url, None, token)
             .await
@@ -295,8 +295,8 @@ impl HttpAgent for SecureHttpAgent {
         T: Request + Serialize + 'a,
     {
         let url = self.base.build_url(resource, query)?;
-        let data = self.base.convert_request(body)?;
-        let token = self.build_token(Method::POST, resource)?;
+        let data = HttpAgentBase::convert_request(body)?;
+        let token = self.build_token(&Method::POST, resource)?;
         self.base
             .execute_request(Method::POST, url, Some(data), token)
             .await
@@ -312,8 +312,8 @@ impl HttpAgent for SecureHttpAgent {
         T: Request + Serialize + 'a,
     {
         let url = self.base.build_url(resource, query)?;
-        let data = self.base.convert_request(body)?;
-        let token = self.build_token(Method::PUT, resource)?;
+        let data = HttpAgentBase::convert_request(body)?;
+        let token = self.build_token(&Method::PUT, resource)?;
         self.base
             .execute_request(Method::PUT, url, Some(data), token)
             .await
@@ -321,7 +321,7 @@ impl HttpAgent for SecureHttpAgent {
 
     async fn delete(&mut self, resource: &str, query: &impl Query) -> CbResult<Response> {
         let url = self.base.build_url(resource, query)?;
-        let token = self.build_token(Method::DELETE, resource)?;
+        let token = self.build_token(&Method::DELETE, resource)?;
         self.base
             .execute_request(Method::DELETE, url, None, token)
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,13 @@
 //! come in future updates. Use it as your own discretion and be mindful that bugs most likely
 //! exist. I hold no responsibility for any issues that occur by using this software and welcome
 //! contributions.
-
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::return_self_not_must_use,
+    clippy::must_use_candidate,
+    clippy::module_name_repetitions,
+    clippy::struct_excessive_bools
+)]
 #![cfg_attr(all(test, feature = "full"), deny(unreachable_pub))]
 #![cfg_attr(all(test, feature = "full"), deny(warnings))]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub mod time;
 pub mod traits;
 pub mod types;
 pub(crate) mod utils;
+pub use utils::FunctionCallback;
 
 pub(crate) mod apis;
 pub(crate) mod models;
@@ -39,3 +40,6 @@ mod rest;
 mod websocket;
 pub use rest::{RestClient, RestClientBuilder};
 pub use websocket::{WebSocketClient, WebSocketClientBuilder};
+
+// Re-export async_trait for the end-user.
+pub use async_trait::async_trait;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,11 +30,8 @@ pub mod types;
 pub(crate) mod utils;
 pub use utils::FunctionCallback;
 
-pub(crate) mod apis;
-pub(crate) mod models;
-pub use models::{
-    account, convert, fee, order, portfolio, product, public, shared, websocket as ws,
-};
+pub mod apis;
+pub mod models;
 
 mod rest;
 mod websocket;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,4 @@
+/// Checks if the agent is authenticated, returns an error if not.
 macro_rules! get_auth {
     ($agent:expr, $method_name:expr) => {
         match $agent {
@@ -12,6 +13,7 @@ macro_rules! get_auth {
     };
 }
 
+/// Checks if the agent is authenticated, returns an error if not.
 macro_rules! is_auth {
     ($agent:expr, $method_name:expr) => {
         if $agent.is_none() {
@@ -20,5 +22,13 @@ macro_rules! is_auth {
                 $method_name
             )));
         }
+    };
+}
+
+/// Prints out a debug message, wraps `println!` macro.
+#[macro_export]
+macro_rules! debugln {
+    ($fmt:expr $(, $($arg:tt)*)?) => {
+        println!(concat!("[DEBUG] ", $fmt), $($($arg)*)?);
     };
 }

--- a/src/models/account.rs
+++ b/src/models/account.rs
@@ -63,7 +63,7 @@ pub struct Account {
     pub updated_at: String,
     /// Time at which this account was deleted.
     pub deleted_at: Option<String>,
-    /// Possible values: [ACCOUNT_TYPE_UNSPECIFIED, ACCOUNT_TYPE_CRYPTO, ACCOUNT_TYPE_FIAT, ACCOUNT_TYPE_VAULT]
+    /// Possible values: [`ACCOUNT_TYPE_UNSPECIFIED`, `ACCOUNT_TYPE_CRYPTO`, `ACCOUNT_TYPE_FIAT`, `ACCOUNT_TYPE_VAULT`]
     pub r#type: AccountType,
     /// Whether or not this account is ready to trade.
     pub ready: bool,
@@ -99,8 +99,7 @@ impl Query for AccountListQuery {
     fn check(&self) -> CbResult<()> {
         if self.limit == 0 || self.limit > LIST_ACCOUNT_MAXIMUM {
             return Err(CbError::BadQuery(format!(
-                "Limit must be greater than 0 with a maximum of {}",
-                LIST_ACCOUNT_MAXIMUM
+                "Limit must be greater than 0 with a maximum of {LIST_ACCOUNT_MAXIMUM}"
             )));
         }
         Ok(())
@@ -124,9 +123,9 @@ impl Default for AccountListQuery {
 }
 
 impl AccountListQuery {
-    /// Creates a new AccountListQuery with default values.
+    /// Creates a new `AccountListQuery` with default values.
     pub fn new() -> Self {
-        Default::default()
+        Self::default()
     }
 
     /// Sets the limit for the query. Default is 49 and maximum is 250.

--- a/src/models/convert.rs
+++ b/src/models/convert.rs
@@ -37,7 +37,7 @@ pub enum TradeStatus {
 pub struct Trade {
     /// The trade id, used to get and commit the trade
     pub id: String,
-    /// Possible values: [TRADE_STATUS_UNSPECIFIED, TRADE_STATUS_CREATED, TRADE_STATUS_STARTED, TRADE_STATUS_COMPLETED, TRADE_STATUS_CANCELED]
+    /// Possible values: [`TRADE_STATUS_UNSPECIFIED`, `TRADE_STATUS_CREATED`, `TRADE_STATUS_STARTED`, `TRADE_STATUS_COMPLETED`, `TRADE_STATUS_CANCELED`]
     pub status: TradeStatus,
     pub user_entered_amount: Balance,
     pub amount: Balance,
@@ -201,13 +201,13 @@ impl Request for ConvertQuoteRequest {
 }
 
 impl ConvertQuoteRequest {
-    /// Creates a new instance of the ConvertQuoteRequest.
+    /// Creates a new instance of the `ConvertQuoteRequest`.
     ///
     /// # Arguments
     ///
     /// * `from_account` - The currency of the account to convert from, e.g. USD
     /// * `to_account` - The currency of the account to convert to, e.g. USDC
-    /// * `amount` - The amount to convert in the currency of the from_account.
+    /// * `amount` - The amount to convert in the currency of the `from_account`.
     pub fn new(from_account: &str, to_account: &str, amount: f64) -> Self {
         Self {
             from_account: from_account.to_string(),
@@ -267,7 +267,7 @@ impl Query for ConvertQuery {
 }
 
 impl ConvertQuery {
-    /// Creates a new instance of the ConvertQuery.
+    /// Creates a new instance of the `ConvertQuery`.
     ///
     /// # Arguments
     ///

--- a/src/models/data.rs
+++ b/src/models/data.rs
@@ -37,7 +37,7 @@ impl AsRef<str> for PortfolioType {
     }
 }
 
-/// KeyPermissions represents the permissions associated with an API key.
+/// `KeyPermissions` represents the permissions associated with an API key.
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct KeyPermissions {
     ///Indicates whether the API key has view permissions.

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,3 +1,7 @@
+//! # Models returned by the API or used to request data from the API.
+//!
+//! Models are the structures that represent the data that is used to request and return data from the API.
+
 pub mod account;
 pub mod convert;
 pub mod data;

--- a/src/models/order/enums.rs
+++ b/src/models/order/enums.rs
@@ -12,7 +12,7 @@ use super::{
 };
 
 /// Various order types.
-#[derive(Serialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Debug, Clone, PartialEq, Copy)]
 pub enum OrderType {
     /// Unknown order type.
     #[serde(rename = "UNKNOWN_ORDER_TYPE")]
@@ -49,7 +49,7 @@ impl AsRef<str> for OrderType {
 }
 
 /// Order side, BUY or SELL.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Copy)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum OrderSide {
     /// Unknown order side. Only used by remote API.
@@ -78,7 +78,7 @@ impl AsRef<str> for OrderSide {
 }
 
 /// Used to sort results.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Copy)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum OrderSortBy {
     /// Unknown sort by.
@@ -113,7 +113,7 @@ impl AsRef<str> for OrderSortBy {
 }
 
 /// Order status, OPEN, CANCELLED, and EXPIRED.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Copy)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum OrderStatus {
     /// Order is pending.
@@ -139,7 +139,7 @@ pub enum OrderStatus {
 
 impl fmt::Display for OrderStatus {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -158,7 +158,7 @@ impl AsRef<str> for OrderStatus {
         }
     }
 }
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Copy)]
 pub enum StopDirection {
     /// Unknown stop direction.
     #[serde(rename = "UNKNOWN_STOP_DIRECTION")]
@@ -173,11 +173,11 @@ pub enum StopDirection {
 
 impl fmt::Display for StopDirection {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Copy)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum TimeInForce {
     /// Unknown time in force.
@@ -213,7 +213,7 @@ impl AsRef<str> for TimeInForce {
 }
 
 /// Enum representing the different possible trigger statuses.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Copy)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum TriggerStatus {
     /// Unknown time in force.
@@ -229,7 +229,7 @@ pub enum TriggerStatus {
 
 impl fmt::Display for TriggerStatus {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -245,7 +245,7 @@ impl AsRef<str> for TriggerStatus {
 }
 
 /// Enum representing reasons for rejecting an order.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Copy)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RejectReason {
     /// Unspecified reject reason.
@@ -265,7 +265,7 @@ pub enum RejectReason {
 
 impl fmt::Display for RejectReason {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/src/models/order/queries.rs
+++ b/src/models/order/queries.rs
@@ -5,7 +5,7 @@
 use serde::Serialize;
 
 use crate::errors::CbError;
-use crate::product::ProductType;
+use crate::models::product::ProductType;
 use crate::utils::QueryBuilder;
 use crate::{traits::Query, types::CbResult};
 

--- a/src/models/order/queries.rs
+++ b/src/models/order/queries.rs
@@ -34,7 +34,7 @@ pub struct OrderListQuery {
     pub end_date: Option<String>,
     /// Only returns the orders where the quote, base or underlying asset matches the provided asset filter(s) (e.g. 'BTC').
     pub asset_filters: Option<Vec<String>>,
-    /// A pagination limit with no default set. If has_next is true, additional orders are available to be fetched with pagination; also the cursor value in the response can be passed as cursor parameter in the subsequent request.
+    /// A pagination limit with no default set. If `has_next` is true, additional orders are available to be fetched with pagination; also the cursor value in the response can be passed as cursor parameter in the subsequent request.
     pub limit: Option<u32>,
     /// Cursor used for pagination. When provided, the response returns responses after this cursor.
     pub cursor: Option<String>,
@@ -156,7 +156,7 @@ impl OrderListQuery {
         self
     }
 
-    /// A pagination limit with no default set. If has_next is true, additional orders are available to be fetched with pagination; also the cursor value in the response can be passed as cursor parameter in the subsequent request.
+    /// A pagination limit with no default set. If `has_next` is true, additional orders are available to be fetched with pagination; also the cursor value in the response can be passed as cursor parameter in the subsequent request.
     pub fn limit(mut self, limit: u32) -> Self {
         self.limit = Some(limit);
         self

--- a/src/models/order/serde_utils.rs
+++ b/src/models/order/serde_utils.rs
@@ -1,6 +1,6 @@
 //! # Coinbase Advanced Order API
 //!
-//! `order/serde_utils` is the module containing the serde utility functions for the OrderType enum.
+//! `order/serde_utils` is the module containing the serde utility functions for the `OrderType` enum.
 
 use std::fmt;
 

--- a/src/models/order/types.rs
+++ b/src/models/order/types.rs
@@ -5,7 +5,7 @@
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DefaultOnError, DisplayFromStr};
 
-use crate::product::ProductType;
+use crate::models::product::ProductType;
 
 use super::{
     OrderSide, OrderStatus, OrderType, RejectReason, StopDirection, TimeInForce, TriggerStatus,

--- a/src/models/product.rs
+++ b/src/models/product.rs
@@ -15,6 +15,7 @@ use crate::time::{self, Granularity};
 use crate::traits::Query;
 use crate::types::CbResult;
 use crate::utils::QueryBuilder;
+use crate::ws::CandleUpdate;
 
 use super::order::OrderSide;
 
@@ -300,6 +301,12 @@ pub struct Candle {
     /// Volume of trading activity during the bucket interval.
     #[serde_as(as = "DisplayFromStr")]
     pub volume: f64,
+}
+
+impl From<CandleUpdate> for Candle {
+    fn from(candle_update: CandleUpdate) -> Self {
+        candle_update.data
+    }
 }
 
 /// Represents a trade for a product.

--- a/src/models/product.rs
+++ b/src/models/product.rs
@@ -11,11 +11,11 @@ use serde_with::{serde_as, DefaultOnError, DisplayFromStr};
 
 use crate::constants::products::CANDLE_MAXIMUM;
 use crate::errors::CbError;
+use crate::models::websocket::CandleUpdate;
 use crate::time::{self, Granularity};
 use crate::traits::Query;
 use crate::types::CbResult;
 use crate::utils::QueryBuilder;
-use crate::ws::CandleUpdate;
 
 use super::order::OrderSide;
 

--- a/src/models/product.rs
+++ b/src/models/product.rs
@@ -138,11 +138,11 @@ pub struct FutureDetails {
     /// Descriptive name for the product series, eg "Nano Bitcoin Futures".
     pub group_description: String,
     pub contract_expiry_timezone: String,
-    /// Short version of the group_description, eg "Nano BTC".
+    /// Short version of the `group_description`, eg "Nano BTC".
     pub group_short_description: String,
-    /// Possible values: [UNKNOWN_RISK_MANAGEMENT_TYPE, MANAGED_BY_FCM, MANAGED_BY_VENUE]
+    /// Possible values: [`UNKNOWN_RISK_MANAGEMENT_TYPE`, `MANAGED_BY_FCM`, `MANAGED_BY_VENUE`]
     pub risk_managed_by: String,
-    /// Possible values: [UNKNOWN_CONTRACT_EXPIRY_TYPE, EXPIRING]
+    /// Possible values: [`UNKNOWN_CONTRACT_EXPIRY_TYPE`, EXPIRING]
     pub contract_expiry_type: String,
     pub perpetual_details: Option<PerpetualDetails>,
     /// Name of the contract.
@@ -358,7 +358,7 @@ pub struct ProductListQuery {
     pub product_ids: Option<Vec<String>>,
     /// If true, return all products of all product types (including expired futures contracts).
     pub get_all_products: Option<bool>,
-    /// Whether or not to populate view_only with the tradability status of the product. This is only enabled for SPOT products.
+    /// Whether or not to populate `view_only` with the tradability status of the product. This is only enabled for SPOT products.
     pub get_tradability_status: Option<bool>,
 }
 
@@ -399,7 +399,7 @@ impl Query for ProductListQuery {
 }
 
 impl ProductListQuery {
-    /// Creates a new ProductListQuery object with default values.
+    /// Creates a new `ProductListQuery` object with default values.
     pub fn new() -> Self {
         Self::default()
     }
@@ -434,7 +434,7 @@ impl ProductListQuery {
         self
     }
 
-    /// Whether or not to populate view_only with the tradability status of the product. This is only enabled for SPOT products.
+    /// Whether or not to populate `view_only` with the tradability status of the product. This is only enabled for SPOT products.
     pub fn get_tradability_status(mut self, get_tradability_status: bool) -> Self {
         self.get_tradability_status = Some(get_tradability_status);
         self
@@ -487,7 +487,7 @@ impl Default for ProductTickerQuery {
 }
 
 impl ProductTickerQuery {
-    /// Creates a new ProductTickerQuery object with default values.
+    /// Creates a new `ProductTickerQuery` object with default values.
     ///
     /// # Arguments
     ///
@@ -538,7 +538,7 @@ impl Query for ProductBidAskQuery {
 }
 
 impl ProductBidAskQuery {
-    /// Creates a new ProductBidAskQuery object with default values.
+    /// Creates a new `ProductBidAskQuery` object with default values.
     pub fn new() -> Self {
         Self::default()
     }
@@ -594,7 +594,7 @@ impl Query for ProductBookQuery {
 }
 
 impl ProductBookQuery {
-    /// Creates a new ProductBookQuery object with default values.
+    /// Creates a new `ProductBookQuery` object with default values.
     ///
     /// # Arguments
     ///
@@ -673,7 +673,7 @@ impl Query for ProductCandleQuery {
 impl Default for ProductCandleQuery {
     fn default() -> Self {
         Self {
-            start: time::now() - Granularity::to_secs(&Granularity::OneDay) as u64,
+            start: time::now() - u64::from(Granularity::to_secs(&Granularity::OneDay)),
             end: time::now(),
             granularity: Granularity::FiveMinute,
             limit: CANDLE_MAXIMUM,
@@ -682,7 +682,7 @@ impl Default for ProductCandleQuery {
 }
 
 impl ProductCandleQuery {
-    /// Creates a new ProductCandleQuery object with default values.
+    /// Creates a new `ProductCandleQuery` object with default values.
     ///
     /// # Arguments
     ///

--- a/src/models/websocket/events.rs
+++ b/src/models/websocket/events.rs
@@ -1,8 +1,8 @@
 use serde::Deserialize;
 
 use super::{
-    CandleUpdate, EventType, Level2Update, MarketTradesUpdate, OrderUpdate, ProductUpdate,
-    SubscribeUpdate, TickerUpdate,
+    CandleUpdate, EventType, FuturesBalanceSummaryUpdate, Level2Update, MarketTradesUpdate,
+    OrderUpdate, ProductUpdate, SubscribeUpdate, TickerUpdate,
 };
 
 /// Events that could be received in a message.
@@ -17,6 +17,7 @@ pub enum Event {
     MarketTrades(MarketTradesEvent),
     Heartbeats(HeartbeatsEvent),
     Subscribe(SubscribeEvent),
+    FuturesBalanceSummary(FuturesSummaryBalanceEvent),
 }
 
 /// The status event containing updates to products.
@@ -73,4 +74,11 @@ pub struct HeartbeatsEvent {
 #[derive(Deserialize, Debug)]
 pub struct SubscribeEvent {
     pub subscriptions: SubscribeUpdate,
+}
+
+/// The futures summary balance event containing the current futures account balance.
+#[derive(Deserialize, Debug)]
+pub struct FuturesSummaryBalanceEvent {
+    pub r#type: EventType,
+    pub fcm_balance_summary: FuturesBalanceSummaryUpdate,
 }

--- a/src/models/websocket/responses.rs
+++ b/src/models/websocket/responses.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DefaultOnError, DisplayFromStr};
 
-use crate::order::{OrderSide, OrderStatus, OrderType, TimeInForce, TriggerStatus};
-use crate::product::{Candle, ProductType};
+use crate::models::order::{OrderSide, OrderStatus, OrderType, TimeInForce, TriggerStatus};
+use crate::models::product::{Candle, ProductType};
 
 use super::Level2Side;
 

--- a/src/models/websocket/responses.rs
+++ b/src/models/websocket/responses.rs
@@ -173,3 +173,52 @@ pub struct OrderUpdate {
     pub end_time: String,
     pub start_time: String,
 }
+
+/// Represents a Futures Balance Summary update received from the Websocket API.
+#[serde_as]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct FuturesBalanceSummaryUpdate {
+    #[serde_as(as = "DisplayFromStr")]
+    futures_buying_power: f64,
+    #[serde_as(as = "DisplayFromStr")]
+    total_usd_balance: f64,
+    #[serde_as(as = "DisplayFromStr")]
+    cbi_usd_balance: f64,
+    #[serde_as(as = "DisplayFromStr")]
+    cfm_usd_balance: f64,
+    #[serde_as(as = "DisplayFromStr")]
+    total_open_orders_hold_amount: f64,
+    #[serde_as(as = "DisplayFromStr")]
+    unrealized_pnl: f64,
+    #[serde_as(as = "DisplayFromStr")]
+    daily_realized_pnl: f64,
+    #[serde_as(as = "DisplayFromStr")]
+    initial_margin: f64,
+    #[serde_as(as = "DisplayFromStr")]
+    available_margin: f64,
+    #[serde_as(as = "DisplayFromStr")]
+    liquidation_threshold: f64,
+    #[serde_as(as = "DisplayFromStr")]
+    liquidation_buffer_amount: f64,
+    #[serde_as(as = "DisplayFromStr")]
+    liquidation_buffer_percentage: u32,
+    intraday_margin_window_measure: MarginWindowMeasure,
+    overnight_margin_window_measure: MarginWindowMeasure,
+}
+
+#[serde_as]
+#[derive(Debug, Deserialize, Serialize, Clone)]
+struct MarginWindowMeasure {
+    margin_window_type: String,
+    margin_level: String,
+    #[serde_as(as = "DisplayFromStr")]
+    initial_margin: f64,
+    #[serde_as(as = "DisplayFromStr")]
+    maintenance_margin: f64,
+    #[serde_as(as = "DisplayFromStr")]
+    liquidation_buffer_percentage: u32,
+    #[serde_as(as = "DisplayFromStr")]
+    total_hold: f64,
+    #[serde_as(as = "DisplayFromStr")]
+    futures_buying_power: f64,
+}

--- a/src/models/websocket/types.rs
+++ b/src/models/websocket/types.rs
@@ -1,12 +1,17 @@
 use std::collections::{HashMap, HashSet};
+use std::pin::Pin;
 use std::sync::Arc;
 
+use futures::Stream;
+use futures_util::stream::{self, SelectAll};
 use serde::Serialize;
 use tokio::sync::Mutex;
+use tokio_tungstenite::tungstenite::{Error as WsError, Message as WsMessage};
 
 use super::{Channel, Endpoint, EndpointType};
-use crate::types::WebSocketReader;
+use crate::types::Socket;
 
+type SplitStream = stream::SplitStream<Socket>;
 type ChannelSubscriptions = HashMap<Channel, Vec<String>>;
 
 /// Secure (authenticated) Subscription is sent to the WebSocket to enable updates for specified Channels.
@@ -96,20 +101,14 @@ impl WebSocketEndpoints {
         self.get(&EndpointType::User)
     }
 
-    /// Converts the WebSocketEndpoints into a vector of WebSocketReaders.
-    pub(crate) fn extract_to_vec(&mut self) -> Vec<WebSocketReader> {
-        let mut readers = Vec::new();
-        let keys: Vec<EndpointType> = self.endpoints.keys().cloned().collect();
-        for key in keys {
-            if let Some(endpoint) = self.endpoints.remove(&key) {
-                match endpoint {
-                    Endpoint::Public((_route, reader)) => readers.push(reader),
-                    Endpoint::User((_route, reader)) => readers.push(reader),
-                }
-            }
+    /// Converts the WebSocketEndpoints into a vector of Endpoints.
+    pub(crate) fn extract_to_vec(&mut self) -> Vec<Endpoint> {
+        let mut endpoints = Vec::new();
+        for (_, endpoint) in self.endpoints.drain() {
+            endpoints.push(endpoint);
         }
 
-        readers
+        endpoints
     }
 }
 
@@ -193,5 +192,56 @@ impl WebSocketSubscriptions {
     pub(crate) async fn get_keys(&self) -> Vec<EndpointType> {
         let keys: Vec<EndpointType> = self.data.keys().cloned().collect();
         keys
+    }
+}
+
+/// Stream of WebSocket messages from one or more endpoints.
+pub enum EndpointStream {
+    /// A single endpoint stream.
+    Single(EndpointType, SplitStream),
+    /// Multiple endpoint streams.
+    Multiple(SelectAll<SplitStream>),
+}
+
+impl From<Endpoint> for EndpointStream {
+    fn from(endpoint: Endpoint) -> Self {
+        match endpoint {
+            // Convert the endpoint into a single stream.
+            Endpoint::Public((route, reader)) | Endpoint::User((route, reader)) => {
+                EndpointStream::Single(route, reader)
+            }
+        }
+    }
+}
+
+impl From<Vec<Endpoint>> for EndpointStream {
+    fn from(endpoints: Vec<Endpoint>) -> Self {
+        let mut select_all = SelectAll::new();
+
+        // Iterate over each endpoint and convert it into a single stream.
+        for endpoint in endpoints {
+            match endpoint {
+                // Convert the endpoint into a single stream.
+                Endpoint::Public((_, reader)) | Endpoint::User((_, reader)) => {
+                    select_all.push(reader);
+                }
+            }
+        }
+
+        EndpointStream::Multiple(select_all)
+    }
+}
+
+impl Stream for EndpointStream {
+    type Item = Result<WsMessage, WsError>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        match self.get_mut() {
+            EndpointStream::Single(_, stream) => Pin::new(stream).poll_next(cx),
+            EndpointStream::Multiple(stream) => Pin::new(stream).poll_next(cx),
+        }
     }
 }

--- a/src/models/websocket/types.rs
+++ b/src/models/websocket/types.rs
@@ -50,12 +50,12 @@ pub struct WebSocketEndpoints {
 }
 
 impl WebSocketEndpoints {
-    /// Create a new WebSocketEndpoints.
+    /// Create a new `WebSocketEndpoints`.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Add an endpoint to the WebSocketEndpoints.
+    /// Add an endpoint to the `WebSocketEndpoints`.
     ///
     /// # Arguments
     ///
@@ -64,7 +64,7 @@ impl WebSocketEndpoints {
         self.endpoints.insert(endpoint_type, endpoint);
     }
 
-    /// Check if the WebSocketEndpoints contains an endpoint.
+    /// Check if the `WebSocketEndpoints` contains an endpoint.
     ///
     /// # Arguments
     ///
@@ -73,7 +73,7 @@ impl WebSocketEndpoints {
         self.endpoints.get(endpoint_type)
     }
 
-    /// Check if the WebSocketEndpoints contains a mutable reference to an endpoint.
+    /// Check if the `WebSocketEndpoints` contains a mutable reference to an endpoint.
     ///
     /// # Arguments
     ///
@@ -82,7 +82,7 @@ impl WebSocketEndpoints {
         self.endpoints.get_mut(endpoint_type)
     }
 
-    /// Take an endpoint from the WebSocketEndpoints.
+    /// Take an endpoint from the `WebSocketEndpoints`.
     ///
     /// # Arguments
     ///
@@ -101,7 +101,7 @@ impl WebSocketEndpoints {
         self.get(&EndpointType::User)
     }
 
-    /// Converts the WebSocketEndpoints into a vector of Endpoints.
+    /// Converts the `WebSocketEndpoints` into a vector of Endpoints.
     pub(crate) fn extract_to_vec(&mut self) -> Vec<Endpoint> {
         let mut endpoints = Vec::new();
         for (_, endpoint) in self.endpoints.drain() {
@@ -127,7 +127,7 @@ impl Default for WebSocketSubscriptions {
 }
 
 impl WebSocketSubscriptions {
-    /// Create a new WebSocketSubscriptions.
+    /// Create a new `WebSocketSubscriptions`.
     pub(crate) fn new() -> Self {
         Self::default()
     }
@@ -189,7 +189,7 @@ impl WebSocketSubscriptions {
     }
 
     /// Obtains all of the keys (endpoints) that have subscriptions.
-    pub(crate) async fn get_keys(&self) -> Vec<EndpointType> {
+    pub(crate) fn get_keys(&self) -> Vec<EndpointType> {
         let keys: Vec<EndpointType> = self.data.keys().cloned().collect();
         keys
     }

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -19,7 +19,7 @@ use crate::config::ConfigFile;
 use crate::token_bucket::{RateLimits, TokenBucket};
 use crate::types::CbResult;
 
-/// Used to create a new RestClient.
+/// Builds a new REST Client (RestClient) that directly interacts with the Coinbase Advanced API.
 #[derive(Default)]
 pub struct RestClientBuilder {
     api_key: Option<String>,
@@ -121,7 +121,7 @@ impl RestClientBuilder {
     }
 }
 
-/// Represents a Client for the API.
+/// Represents a REST Client for interacting with the Coinbase Advanced API.
 pub struct RestClient {
     /// Gives access to the Account API.
     pub account: AccountApi,

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -19,7 +19,7 @@ use crate::config::ConfigFile;
 use crate::token_bucket::{RateLimits, TokenBucket};
 use crate::types::CbResult;
 
-/// Builds a new REST Client (RestClient) that directly interacts with the Coinbase Advanced API.
+/// Builds a new REST Client (`RestClient`) that directly interacts with the Coinbase Advanced API.
 #[derive(Default)]
 pub struct RestClientBuilder {
     api_key: Option<String>,
@@ -28,7 +28,7 @@ pub struct RestClientBuilder {
 }
 
 impl RestClientBuilder {
-    /// Creates a new instance of a RestClientBuilder.
+    /// Creates a new instance of a `RestClientBuilder`.
     pub fn new() -> Self {
         Self {
             api_key: None,
@@ -41,7 +41,7 @@ impl RestClientBuilder {
     ///
     /// # Arguments
     ///
-    /// * `config` - Configuration that implements ConfigFile trait.
+    /// * `config` - Configuration that implements `ConfigFile` trait.
     #[cfg(feature = "config")]
     pub fn with_config<T>(mut self, config: &T) -> Self
     where
@@ -65,7 +65,7 @@ impl RestClientBuilder {
         self
     }
 
-    /// Sets the use_sandbox flag for the client.
+    /// Sets the `use_sandbox` flag for the client.
     ///
     /// # Arguments
     ///
@@ -75,7 +75,11 @@ impl RestClientBuilder {
         self
     }
 
-    /// Builds the RestClient.
+    /// Builds the `RestClient`.
+    ///
+    /// # Errors
+    ///
+    /// * `CbError::RequestError` - If there was an issue creating the HTTP client.
     pub fn build(self) -> CbResult<RestClient> {
         // Initialize token buckets
         let secure_bucket = Arc::new(Mutex::new(TokenBucket::new(
@@ -88,14 +92,11 @@ impl RestClientBuilder {
             RateLimits::refresh_rate(true, true),
         )));
 
-        // Determine if authentication is enabled.
-        let is_authenticated = self.api_key.is_some() && self.api_secret.is_some();
-
         // Initialize agents.
-        let secure_agent = if is_authenticated {
+        let secure_agent = if let (Some(key), Some(secret)) = (self.api_key, self.api_secret) {
             Some(SecureHttpAgent::new(
-                &self.api_key.unwrap(),
-                &self.api_secret.unwrap(),
+                &key,
+                &secret,
                 self.use_sandbox,
                 secure_bucket,
             )?)

--- a/src/time.rs
+++ b/src/time.rs
@@ -138,11 +138,15 @@ impl Span {
     }
 
     /// Total amount of intervals within the span.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of intervals is greater than `usize`.
     pub fn count(&self) -> usize {
         // Clean the time, they have to be the correct offset.
-        let end = self.end - (self.end % self.granularity as u64);
-        let start = self.start - (self.start % self.granularity as u64);
-        ((end - start) / self.granularity as u64) as usize
+        let end = self.end - (self.end % u64::from(self.granularity));
+        let start = self.start - (self.start % u64::from(self.granularity));
+        usize::try_from((end - start) / u64::from(self.granularity)).unwrap()
     }
 }
 
@@ -169,6 +173,10 @@ impl Query for Span {
 }
 
 /// Obtains the current timestamp in UNIX format.
+///
+/// # Panics
+///
+/// Panics if the system time is before the UNIX epoch.
 pub fn now() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/src/token_bucket.rs
+++ b/src/token_bucket.rs
@@ -27,13 +27,15 @@ impl RateLimits {
     /// * `is_public` - Requester is Public Client, true, otherwise false.
     pub(crate) fn refresh_rate(is_rest: bool, is_public: bool) -> f64 {
         if is_rest {
-            is_public
-                .then(|| ratelimits::PUBLIC_REST_REFRESH_RATE)
-                .unwrap_or(ratelimits::SECURE_REST_REFRESH_RATE)
+            if is_public {
+                ratelimits::PUBLIC_REST_REFRESH_RATE
+            } else {
+                ratelimits::SECURE_REST_REFRESH_RATE
+            }
+        } else if is_public {
+            ratelimits::PUBLIC_WEBSOCKET_REFRESH_RATE
         } else {
-            is_public
-                .then(|| ratelimits::PUBLIC_WEBSOCKET_REFRESH_RATE)
-                .unwrap_or(ratelimits::SECURE_WEBSOCKET_REFRESH_RATE)
+            ratelimits::SECURE_WEBSOCKET_REFRESH_RATE
         }
     }
 
@@ -45,13 +47,15 @@ impl RateLimits {
     /// * `is_public` - Requester is Public Client, true, otherwise false.
     pub(crate) fn max_tokens(is_rest: bool, is_public: bool) -> f64 {
         if is_rest {
-            is_public
-                .then(|| RateLimits::PUBLIC_REST_MAX_TOKENS)
-                .unwrap_or(RateLimits::SECURE_REST_MAX_TOKENS)
+            if is_public {
+                RateLimits::PUBLIC_REST_MAX_TOKENS
+            } else {
+                RateLimits::SECURE_REST_MAX_TOKENS
+            }
+        } else if is_public {
+            RateLimits::PUBLIC_WEBSOCKET_MAX_TOKENS
         } else {
-            is_public
-                .then(|| RateLimits::PUBLIC_WEBSOCKET_MAX_TOKENS)
-                .unwrap_or(RateLimits::SECURE_WEBSOCKET_MAX_TOKENS)
+            RateLimits::SECURE_WEBSOCKET_MAX_TOKENS
         }
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -57,7 +57,7 @@ impl Query for NoQuery {
     }
 }
 
-/// Trait for the HttpAgent that is responsible for making HTTP requests and managing the token bucket.
+/// Trait for the `HttpAgent` that is responsible for making HTTP requests and managing the token bucket.
 pub(crate) trait HttpAgent {
     /// Performs a HTTP GET Request.
     ///

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -8,6 +8,7 @@ use crate::models::{product::Candle, websocket::Message};
 use crate::types::CbResult;
 
 /// Used to pass to a callback to the candle watcher on a successful ejection.
+#[async_trait]
 pub trait CandleCallback {
     /// Called when a candle is succesfully ejected.
     ///
@@ -16,7 +17,7 @@ pub trait CandleCallback {
     /// * `current_start` - Current UTC timestamp for a start.
     /// * `product_id` - Product the candle belongs to.
     /// * `candle` - Candle that was recently completed.
-    fn candle_callback(&mut self, current_start: u64, product_id: String, candle: Candle);
+    async fn candle_callback(&mut self, current_start: u64, product_id: String, candle: Candle);
 }
 
 /// Used to pass objects to the listener for greater control over message processing.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,6 @@
 //! Traits used to allow interfacing with advanced functionality for end-users.
 
+use async_trait::async_trait;
 use reqwest::Response;
 use serde::Serialize;
 
@@ -19,13 +20,14 @@ pub trait CandleCallback {
 }
 
 /// Used to pass objects to the listener for greater control over message processing.
+#[async_trait]
 pub trait MessageCallback {
     /// This is called when processing a message from the WebSocket.
     ///
     /// # Arguments
     ///
     /// * `msg` - Message or Error received from the WebSocket.
-    fn message_callback(&mut self, msg: CbResult<Message>);
+    async fn message_callback(&mut self, msg: CbResult<Message>);
 }
 
 /// Used to pass query/paramters for a URL.

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,15 +4,12 @@ use futures_util::stream::SplitStream;
 use tokio::net::TcpStream;
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
-use crate::{errors::CbError, models::websocket::Message};
+use crate::errors::CbError;
 
 /// Used to return objects from the API to the end-user.
 pub type CbResult<T> = Result<T, CbError>;
 
 pub(crate) type Socket = WebSocketStream<MaybeTlsStream<TcpStream>>;
-
-/// Used to define a custom callback for messages to be passed to.
-pub type MessageCallbackFn = fn(CbResult<Message>);
 
 /// The 'Read' of a split socket.
 pub type WebSocketReader = SplitStream<Socket>;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,14 +3,13 @@
 //! `utils` is a collection of helpful tools that may be required throughout the rest of the API.
 
 use std::fmt::{Display, Write};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
 
-/// Prints out a debug message, wraps `println!` macro.
-#[macro_export]
-macro_rules! debugln {
-    ($fmt:expr $(, $($arg:tt)*)?) => {
-        println!(concat!("[DEBUG] ", $fmt), $($($arg)*)?);
-    };
-}
+use async_trait::async_trait;
+
+use crate::{traits::MessageCallback, types::CbResult, ws::Message};
 
 /// Builds the URL Query to be sent to the API.
 pub(crate) struct QueryBuilder {
@@ -67,5 +66,69 @@ impl QueryBuilder {
     /// Builds and returns the final query string.
     pub(crate) fn build(self) -> String {
         self.query
+    }
+}
+
+type BoxCallback =
+    Box<dyn Fn(CbResult<Message>) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
+
+/// A callback function that can be used to handle messages.
+pub struct FunctionCallback {
+    callback: Arc<BoxCallback>,
+}
+
+impl FunctionCallback {
+    /// Creates a new `FunctionCallback` from an asynchronous function.
+    ///
+    /// # Arguments
+    ///
+    /// * `async_fn` - The asynchronous function to be called when a message is received.
+    pub fn from_async<F, Fut>(async_fn: F) -> Self
+    where
+        F: Fn(CbResult<Message>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        let callback = move |msg: CbResult<Message>| -> Pin<Box<dyn Future<Output = ()> + Send>> {
+            let fut = async_fn(msg);
+            Box::pin(fut)
+        };
+
+        Self {
+            callback: Arc::new(Box::new(callback)),
+        }
+    }
+
+    /// Creates a new `FunctionCallback` from a synchronous function.
+    ///
+    /// # Arguments
+    ///
+    /// * `sync_fn` - The synchronous function to be called when a message is received.
+    pub fn from_sync<F>(sync_fn: F) -> Self
+    where
+        F: Fn(CbResult<Message>) + Send + Sync + 'static,
+    {
+        let sync_fn = Arc::new(sync_fn);
+
+        let callback = {
+            let sync_fn = Arc::clone(&sync_fn);
+            move |msg: CbResult<Message>| -> Pin<Box<dyn Future<Output = ()> + Send>> {
+                let sync_fn = Arc::clone(&sync_fn);
+                Box::pin(async move {
+                    (sync_fn)(msg);
+                })
+            }
+        };
+
+        Self {
+            callback: Arc::new(Box::new(callback)),
+        }
+    }
+}
+
+#[async_trait]
+impl MessageCallback for FunctionCallback {
+    async fn message_callback(&mut self, msg: CbResult<Message>) {
+        let callback = Arc::clone(&self.callback);
+        (callback)(msg).await;
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,7 +9,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use crate::{traits::MessageCallback, types::CbResult, ws::Message};
+use crate::models::websocket::Message;
+use crate::traits::MessageCallback;
+use crate::types::CbResult;
 
 /// Builds the URL Query to be sent to the API.
 pub(crate) struct QueryBuilder {
@@ -72,7 +74,7 @@ impl QueryBuilder {
 type BoxCallback =
     Box<dyn Fn(CbResult<Message>) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
 
-/// A callback function that can be used to handle messages.
+/// Used to wrap callback functions for the WebSocket Client's `listen()` function..
 pub struct FunctionCallback {
     callback: Arc<BoxCallback>,
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -38,7 +38,7 @@ impl QueryBuilder {
             self.query.push('&');
         }
 
-        write!(self.query, "{}={}", key, value).unwrap();
+        write!(self.query, "{key}={value}").unwrap();
         self
     }
 

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -19,14 +19,13 @@ use crate::constants::websocket::{PUBLIC_ENDPOINT, SECURE_ENDPOINT};
 use crate::errors::CbError;
 use crate::jwt::Jwt;
 use crate::models::websocket::{
-    Channel, EndpointType, SecureSubscription, Subscription, UnsignedSubscription,
-    WebSocketEndpoints,
+    Channel, Endpoint, EndpointStream, EndpointType, Message, SecureSubscription, Subscription,
+    UnsignedSubscription, WebSocketEndpoints, WebSocketSubscriptions,
 };
 use crate::time;
 use crate::token_bucket::{RateLimits, TokenBucket};
 use crate::traits::{CandleCallback, MessageCallback};
 use crate::types::CbResult;
-use crate::ws::{Endpoint, EndpointStream, Message, WebSocketSubscriptions};
 
 #[cfg(feature = "config")]
 use crate::config::ConfigFile;
@@ -49,7 +48,7 @@ fn get_channel_endpoint(channel: &Channel) -> EndpointType {
     }
 }
 
-/// Builder to create a WebSocketClient.
+/// Builds a new WebSocket Client (WebSocketClient) that directly interacts with the Coinbase Advanced API.
 pub struct WebSocketClientBuilder {
     api_key: Option<String>,
     api_secret: Option<String>,
@@ -195,8 +194,7 @@ impl WebSocketClientBuilder {
     }
 }
 
-/// Represents a Client for the Websocket API. Provides easy-access to subscribing and listening to
-/// the WebSocket.
+/// A WebSocket Client used to interactive with the Coinbase Advanced API. Provides easy-access to subscribing and listening to the WebSocket.
 pub struct WebSocketClient {
     /// Signs the messages sent.
     pub(crate) jwt: Option<Jwt>,


### PR DESCRIPTION
- Increased visibility of `apis::*` to improve documentation.
- General cleaning of the API for documentation due to new linting.
- Refactored the Order Builder to be easier to manage.
- Refactored Message parsing for the WebSocket.
- Removed the `sub` and `unsub` functions from the websocket.
- Added support for the FuturesBalanceSummary channel for the websocket.
- JWT Generation Optimizations.
- Added PANIC and ERROR documentation.
- WebSocket MessageCallbacks are now asynchronous.
- Updated the `websocket` example to demonstrate using a callback function and not trait.
- Re-exporting `async_trait` for user friendliness.
- `FunctionCallback` automatically converts `async` and `sync` functions to trait-based.
- Added the `From` trait to convert from CandleUpdate to Candle.
- Documentation updates.