### PR TITLE
Add serialize for websocket Message

### DIFF
--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -9,7 +9,7 @@
 use std::process::exit;
 use std::time::{Duration, Instant};
 
-use cbadv::models::websocket::{Channel, EndpointStream, Message};
+use cbadv::models::websocket::{Channel, EndpointStream, Events, Message};
 use cbadv::types::CbResult;
 use cbadv::WebSocketClientBuilder;
 
@@ -17,7 +17,20 @@ use cbadv::WebSocketClientBuilder;
 /// the stream.
 fn message_action(msg: CbResult<Message>) -> Result<(), String> {
     let rcvd = match msg {
-        Ok(message) => format!("{message:?}"), // Leverage Debug for all Message variants
+        Ok(Message {
+            events: Events::Candles(candles_events),
+            channel,
+            ..
+        }) => {
+            for ticker in candles_events {
+                println!("{ticker:?}");
+            }
+            format!("this is a {channel:?} message")
+        }
+        Ok(message) => format!(
+            "this is not a candles message it is a {:?} message",
+            message.channel
+        ), // Leverage Debug for all Message variants
         Err(error) => format!("Error: {error}"), // Handle WebSocket errors
     };
 

--- a/src/models/websocket/events.rs
+++ b/src/models/websocket/events.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use super::{
     CandleUpdate, EventType, FuturesBalanceSummaryUpdate, Level2Update, MarketTradesUpdate,
@@ -6,7 +6,7 @@ use super::{
 };
 
 /// Events that could be received in a message.
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub enum Event {
     Status(StatusEvent),
     Candles(CandlesEvent),
@@ -21,28 +21,28 @@ pub enum Event {
 }
 
 /// The status event containing updates to products.
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct StatusEvent {
     pub r#type: EventType,
     pub products: Vec<ProductUpdate>,
 }
 
 /// The candles event containing updates to candles.
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct CandlesEvent {
     pub r#type: EventType,
     pub candles: Vec<CandleUpdate>,
 }
 
 /// The ticker event containing updates to tickers.
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct TickerEvent {
     pub r#type: EventType,
     pub tickers: Vec<TickerUpdate>,
 }
 
 /// The level2 event containing updates to the order book.
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Level2Event {
     pub r#type: EventType,
     pub product_id: String,
@@ -50,34 +50,34 @@ pub struct Level2Event {
 }
 
 /// The user event containing updates to orders.
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct UserEvent {
     pub r#type: EventType,
     pub orders: Vec<OrderUpdate>,
 }
 
 /// The market trades event containing updates to trades.
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct MarketTradesEvent {
     pub r#type: EventType,
     pub trades: Vec<MarketTradesUpdate>,
 }
 
 /// The heartbeats event containing the current time and heartbeat counter.
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct HeartbeatsEvent {
     pub current_time: String,
     pub heartbeat_counter: u64,
 }
 
 /// The subscribe event containing the current subscriptions.
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct SubscribeEvent {
     pub subscriptions: SubscribeUpdate,
 }
 
 /// The futures summary balance event containing the current futures account balance.
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct FuturesSummaryBalanceEvent {
     pub r#type: EventType,
     pub fcm_balance_summary: FuturesBalanceSummaryUpdate,

--- a/src/models/websocket/events.rs
+++ b/src/models/websocket/events.rs
@@ -6,18 +6,19 @@ use super::{
 };
 
 /// Events that could be received in a message.
-#[derive(Debug, Serialize)]
-pub enum Event {
-    Status(StatusEvent),
-    Candles(CandlesEvent),
-    Ticker(TickerEvent),
-    TickerBatch(TickerEvent),
-    Level2(Level2Event),
-    User(UserEvent),
-    MarketTrades(MarketTradesEvent),
-    Heartbeats(HeartbeatsEvent),
-    Subscribe(SubscribeEvent),
-    FuturesBalanceSummary(FuturesSummaryBalanceEvent),
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Events {
+    Status(Vec<StatusEvent>),
+    Candles(Vec<CandlesEvent>),
+    Ticker(Vec<TickerEvent>),
+    TickerBatch(Vec<TickerEvent>),
+    Level2(Vec<Level2Event>),
+    User(Vec<UserEvent>),
+    MarketTrades(Vec<MarketTradesEvent>),
+    Heartbeats(Vec<HeartbeatsEvent>),
+    Subscribe(Vec<SubscribeEvent>),
+    FuturesBalanceSummary(Vec<FuturesSummaryBalanceEvent>),
 }
 
 /// The status event containing updates to products.

--- a/src/models/websocket/message.rs
+++ b/src/models/websocket/message.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use serde::de::{self, Deserialize, Deserializer, MapAccess, Visitor};
+use serde::Serialize;
 use serde_json::Value;
 
 use super::{
@@ -9,7 +10,7 @@ use super::{
 };
 
 /// Message from the WebSocket containing event updates.
-#[derive(Debug)]
+#[derive(Serialize, Debug)]
 pub struct Message {
     /// The channel the message is from.
     pub channel: Channel,

--- a/src/models/websocket/message.rs
+++ b/src/models/websocket/message.rs
@@ -1,16 +1,9 @@
-use std::fmt;
+use serde::{Deserialize, Serialize};
 
-use serde::de::{self, Deserialize, Deserializer, MapAccess, Visitor};
-use serde::Serialize;
-use serde_json::Value;
-
-use super::{
-    CandlesEvent, Channel, Event, FuturesSummaryBalanceEvent, HeartbeatsEvent, Level2Event,
-    MarketTradesEvent, StatusEvent, SubscribeEvent, TickerEvent, UserEvent,
-};
+use super::{Channel, Events};
 
 /// Message from the WebSocket containing event updates.
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Message {
     /// The channel the message is from.
     pub channel: Channel,
@@ -21,147 +14,32 @@ pub struct Message {
     /// The sequence number for the message
     pub sequence_num: u64,
     /// The events in the message.
-    pub events: Vec<Event>,
+    pub events: Events,
 }
 
-/// Custom deserialization for Message.
-impl<'de> Deserialize<'de> for Message {
-    fn deserialize<D>(deserializer: D) -> Result<Message, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_map(MessageVisitor)
-    }
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-/// Visitor struct for custom deserialization for Message.
-struct MessageVisitor;
-
-impl<'de> Visitor<'de> for MessageVisitor {
-    type Value = Message;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("a WebSocket message")
-    }
-
-    fn visit_map<M>(self, mut map: M) -> Result<Message, M::Error>
-    where
-        M: MapAccess<'de>,
-    {
-        let mut channel: Option<Channel> = None;
-        let mut client_id: Option<String> = None;
-        let mut timestamp: Option<String> = None;
-        let mut sequence_num: Option<u64> = None;
-        let mut events_value: Option<Value> = None;
-
-        // Extract common fields and store the raw events for later deserialization.
-        while let Some(key) = map.next_key::<&str>()? {
-            match key {
-                "channel" => {
-                    if channel.is_some() {
-                        return Err(de::Error::duplicate_field("channel"));
+    #[test]
+    fn heartbeat_works() {
+        let data = r#"
+            {
+                "channel":"heartbeats",
+                "client_id":"",
+                "timestamp":"2025-01-14T22:11:18.791273556Z",
+                "sequence_num":17,
+                "events":
+                [
+                    {
+                        "current_time":"2025-01-14 22:11:18.787177997 +0000 UTC m=+25541.571430466",
+                        "heartbeat_counter":25539
                     }
-                    channel = Some(map.next_value()?);
-                }
-                "client_id" => {
-                    if client_id.is_some() {
-                        return Err(de::Error::duplicate_field("client_id"));
-                    }
-                    client_id = Some(map.next_value()?);
-                }
-                "timestamp" => {
-                    if timestamp.is_some() {
-                        return Err(de::Error::duplicate_field("timestamp"));
-                    }
-                    timestamp = Some(map.next_value()?);
-                }
-                "sequence_num" => {
-                    if sequence_num.is_some() {
-                        return Err(de::Error::duplicate_field("sequence_num"));
-                    }
-                    sequence_num = Some(map.next_value()?);
-                }
-                "events" => {
-                    if events_value.is_some() {
-                        return Err(de::Error::duplicate_field("events"));
-                    }
-                    // Temporarily store events as serde_json::Value
-                    events_value = Some(map.next_value()?);
-                }
-                _ => {
-                    // Skip unknown fields or handle as needed.
-                    let _ = map.next_value::<de::IgnoredAny>()?;
-                }
+                ]
             }
-        }
+        "#;
 
-        let channel = channel.ok_or_else(|| de::Error::missing_field("channel"))?;
-        let client_id = client_id.ok_or_else(|| de::Error::missing_field("client_id"))?;
-        let timestamp = timestamp.ok_or_else(|| de::Error::missing_field("timestamp"))?;
-        let sequence_num = sequence_num.ok_or_else(|| de::Error::missing_field("sequence_num"))?;
-        let events_value = events_value.ok_or_else(|| de::Error::missing_field("events"))?;
-
-        // Deserialize events based on the channel.
-        let events = deserialize_events(&channel, events_value).map_err(de::Error::custom)?;
-
-        Ok(Message {
-            channel,
-            client_id,
-            timestamp,
-            sequence_num,
-            events,
-        })
-    }
-}
-
-/// Helper function to deserialize events based on the channel.
-fn deserialize_events(
-    channel: &Channel,
-    events_value: Value,
-) -> Result<Vec<Event>, Box<dyn std::error::Error>> {
-    match channel {
-        Channel::Status => {
-            let events: Vec<StatusEvent> = serde_json::from_value(events_value)?;
-            Ok(events.into_iter().map(Event::Status).collect())
-        }
-        Channel::Candles => {
-            let events: Vec<CandlesEvent> = serde_json::from_value(events_value)?;
-            Ok(events.into_iter().map(Event::Candles).collect())
-        }
-        Channel::Ticker => {
-            let events: Vec<TickerEvent> = serde_json::from_value(events_value)?;
-            Ok(events.into_iter().map(Event::Ticker).collect())
-        }
-        Channel::TickerBatch => {
-            let events: Vec<TickerEvent> = serde_json::from_value(events_value)?;
-            Ok(events.into_iter().map(Event::TickerBatch).collect())
-        }
-        Channel::Level2 => {
-            let events: Vec<Level2Event> = serde_json::from_value(events_value)?;
-            Ok(events.into_iter().map(Event::Level2).collect())
-        }
-        Channel::User => {
-            let events: Vec<UserEvent> = serde_json::from_value(events_value)?;
-            Ok(events.into_iter().map(Event::User).collect())
-        }
-        Channel::MarketTrades => {
-            let events: Vec<MarketTradesEvent> = serde_json::from_value(events_value)?;
-            Ok(events.into_iter().map(Event::MarketTrades).collect())
-        }
-        Channel::Heartbeats => {
-            let events: Vec<HeartbeatsEvent> = serde_json::from_value(events_value)?;
-            Ok(events.into_iter().map(Event::Heartbeats).collect())
-        }
-        Channel::Subscriptions => {
-            let events: Vec<SubscribeEvent> = serde_json::from_value(events_value)?;
-            Ok(events.into_iter().map(Event::Subscribe).collect())
-        }
-        Channel::FuturesBalanceSummary => {
-            let events: Vec<FuturesSummaryBalanceEvent> = serde_json::from_value(events_value)?;
-            Ok(events
-                .into_iter()
-                .map(Event::FuturesBalanceSummary)
-                .collect())
-        }
+        let res: Result<Message, serde_json::Error> = serde_json::from_str(data);
+        assert!(res.is_ok());
     }
 }

--- a/src/models/websocket/responses.rs
+++ b/src/models/websocket/responses.rs
@@ -7,7 +7,7 @@ use crate::models::product::{Candle, Product, ProductType};
 use super::Level2Side;
 
 #[serde_as]
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Level2Update {
     pub side: Level2Side,
     pub event_time: String,
@@ -17,7 +17,7 @@ pub struct Level2Update {
     pub new_quantity: f64,
 }
 
-#[derive(Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub struct SubscribeUpdate {
     #[serde(default)]
     pub status: Vec<String>,


### PR DESCRIPTION
This PR adds serde serialize to the `Message` struct in the websockets models.  I wanted to send the message to fluent-bit and eventually s3 in order to archive the messages for playback / debugging.  The current implementation seems to skip adding the derive Serialize trait on a few parts of the Message.  But I have added these and tested it without any issues for heartbeats and tickers.