### PR TITLE
updated JWT algorithm from ECDSA to Ed25519

### DIFF
--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -1,10 +1,8 @@
 use std::str;
 use std::sync::Arc;
 
-use base64::engine::general_purpose::{STANDARD_NO_PAD, URL_SAFE_NO_PAD};
+use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
 use base64::Engine;
-use openssl::ec::EcKey;
-use openssl::pkey::PKey;
 use ring::rand::SecureRandom;
 use ring::rand::SystemRandom;
 use ring::signature::{Ed25519KeyPair};
@@ -35,7 +33,7 @@ struct Payload<'a> {
 pub(crate) struct Jwt {
     /// API Key provided by the service.
     api_key: String,
-    /// Pre-initialized ECDSA signing key pair.
+    /// Pre-initialized Ed25519 signing key pair.
     signing_key: Arc<Ed25519KeyPair>,
     /// RNG for signing.
     rng: SystemRandom,
@@ -54,17 +52,14 @@ impl Clone for Jwt {
 impl Jwt {
     /// Create a new instance of the JSON Web Token (Jwt) used to generate new tokens.
     pub(crate) fn new(api_key: &str, api_secret: &str) -> CbResult<Self> {
-        let secret = Self::format_key(api_secret.as_bytes())?;
 
         // Initialize SystemRandom.
         let rng = SystemRandom::new();
 
-        // Initialize the EcdsaKeyPair once with the RNG.
-        // let signing_key = EcdsaKeyPair::from_pkcs8(Self::get_alg(), &secret, &rng)
-        //     .map_err(|why| CbError::BadSignature(why.to_string()))?;
+        // Initialize the Ed25519KeyPair once.
+        let signing_key_bytes = STANDARD.decode(api_secret)
+                .map_err(|why| CbError::BadSignature(why.to_string()))?;
 
-
-        let signing_key_bytes = STANDARD_NO_PAD.decode(&secret).unwrap();
         let (seed, public_key) = signing_key_bytes.split_at(32);
         let signing_key = Ed25519KeyPair::from_seed_and_public_key(seed, public_key)
                 .map_err(|why| CbError::BadSignature(why.to_string()))?;
@@ -121,89 +116,7 @@ impl Jwt {
         Ok(Self::to_base64(&raw))
     }
 
-    /// Formats a private key into PKCS#8 format and parses it.
-    ///
-    /// This function takes a private key in PEM format, attempts to format it into PKCS#8 format,
-    /// and then parses it. If the key is already in PKCS#8 format, it parses the key directly.
-    /// The function supports both PKCS#1 and PKCS#8 PEM-encoded EC keys.
-    ///
-    /// # Arguments
-    ///
-    /// * `key`: A byte slice (`&[u8]`) containing the private key in PEM format.
-    ///
-    /// # Returns
-    ///
-    /// A `CbResult<Vec<u8>>` with the parsed key data in binary format if successful;
-    /// otherwise, an error.
-    fn format_key(key: &[u8]) -> CbResult<Vec<u8>> {
-        // Check if already in pkcs8 format.
-        if let Ok(pkey) = PKey::private_key_from_pem(key) {
-            if let Ok(serialized) = pkey.private_key_to_pem_pkcs8() {
-                if serialized == key {
-                    return Self::parse_key(key);
-                }
-            }
-        }
-
-        // Not in pkcs8 format, attempt conversion.
-        let ec_key = EcKey::private_key_from_pem(key)
-            .map_err(|why| CbError::BadPrivateKey(why.to_string()))?;
-        let pkey =
-            PKey::from_ec_key(ec_key).map_err(|why| CbError::BadPrivateKey(why.to_string()))?;
-
-        let new_key = pkey
-            .private_key_to_pem_pkcs8()
-            .map_err(|why| CbError::BadPrivateKey(why.to_string()))?;
-
-        Self::parse_key(&new_key)
-    }
-
-    /// Parses a PEM-encoded private key or a base64-encoded key.
-    ///
-    /// This function takes a byte slice representing either a PEM-encoded private key
-    /// (with or without the "-----BEGIN PRIVATE KEY-----" and "-----END PRIVATE KEY-----" delimiters)
-    /// or a base64-encoded key, and returns the raw binary key data.
-    ///
-    /// # Arguments
-    ///
-    /// * `api_secret`: A byte slice (`&[u8]`) containing the PEM or base64-encoded private key.
-    ///
-    /// # Returns
-    ///
-    /// A `CbResult<Vec<u8>>` which is Ok containing the decoded binary key data if successful,
-    /// or an Err with a `CbError::BadPrivateKey` containing the error message if any error occurs.
-    fn parse_key(api_secret: &[u8]) -> CbResult<Vec<u8>> {
-        let pem_str =
-            str::from_utf8(api_secret).map_err(|why| CbError::BadPrivateKey(why.to_string()))?;
-
-        // Checks for the headers and footers to remove them.
-        let base64_encoded = if pem_str.starts_with("-----BEGIN") && pem_str.contains("-----END") {
-            let start = pem_str
-                .find("-----BEGIN")
-                .and_then(|s| pem_str[s..].find('\n'))
-                .ok_or_else(|| CbError::BadPrivateKey("No BEGIN delimiter".to_string()))?
-                + 1;
-
-            let end = pem_str
-                .find("-----END")
-                .ok_or_else(|| CbError::BadPrivateKey("No END delimiter".to_string()))?;
-
-            // Get the data between the header and footer.
-            pem_str[start..end]
-                .lines()
-                .collect::<String>()
-                .replace(['\n', '\r'], "")
-        } else {
-            pem_str.replace(['\n', '\r'], "")
-        };
-
-        // Decode the key.
-        STANDARD_NO_PAD
-            .decode(base64_encoded)
-            .map_err(|why| CbError::BadPrivateKey(why.to_string()))
-    }
-
-    /// Signs a message using the pre-initialized ECDSA key pair.
+    /// Signs a message using the pre-initialized Ed25519 key pair.
     ///
     /// # Arguments
     ///
@@ -234,8 +147,8 @@ impl Jwt {
         let payload = Jwt::base64_encode(&self.build_payload(uri))?;
 
         // Estimate capacity: header + payload + signature + 2 dots
-        // Assuming signature is ~43 characters for ECDSA P-256
-        let mut message = String::with_capacity(header.len() + payload.len() + 50);
+        // Assuming signature is ~86 characters for Ed25519
+        let mut message = String::with_capacity(header.len() + payload.len() + 88);
         message.push_str(&header);
         message.push('.');
         message.push_str(&payload);

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -7,7 +7,7 @@ use openssl::ec::EcKey;
 use openssl::pkey::PKey;
 use ring::rand::SecureRandom;
 use ring::rand::SystemRandom;
-use ring::signature::{self, EcdsaKeyPair};
+use ring::signature::{Ed25519KeyPair};
 use serde::Serialize;
 
 use crate::errors::CbError;
@@ -36,7 +36,7 @@ pub(crate) struct Jwt {
     /// API Key provided by the service.
     api_key: String,
     /// Pre-initialized ECDSA signing key pair.
-    signing_key: Arc<EcdsaKeyPair>,
+    signing_key: Arc<Ed25519KeyPair>,
     /// RNG for signing.
     rng: SystemRandom,
 }
@@ -60,8 +60,14 @@ impl Jwt {
         let rng = SystemRandom::new();
 
         // Initialize the EcdsaKeyPair once with the RNG.
-        let signing_key = EcdsaKeyPair::from_pkcs8(Self::get_alg(), &secret, &rng)
-            .map_err(|why| CbError::BadSignature(why.to_string()))?;
+        // let signing_key = EcdsaKeyPair::from_pkcs8(Self::get_alg(), &secret, &rng)
+        //     .map_err(|why| CbError::BadSignature(why.to_string()))?;
+
+
+        let signing_key_bytes = STANDARD_NO_PAD.decode(&secret).unwrap();
+        let (seed, public_key) = signing_key_bytes.split_at(32);
+        let signing_key = Ed25519KeyPair::from_seed_and_public_key(seed, public_key)
+                .map_err(|why| CbError::BadSignature(why.to_string()))?;
 
         Ok(Self {
             api_key: api_key.to_string(),
@@ -113,11 +119,6 @@ impl Jwt {
         let raw =
             serde_json::to_vec(input).map_err(|why| CbError::BadSignature(why.to_string()))?;
         Ok(Self::to_base64(&raw))
-    }
-
-    #[inline]
-    fn get_alg() -> &'static signature::EcdsaSigningAlgorithm {
-        &signature::ECDSA_P256_SHA256_FIXED_SIGNING
     }
 
     /// Formats a private key into PKCS#8 format and parses it.
@@ -214,8 +215,7 @@ impl Jwt {
     fn sign_message(&self, message: &[u8]) -> CbResult<String> {
         let signature = self
             .signing_key
-            .sign(&self.rng, message)
-            .map_err(|why| CbError::BadSignature(why.to_string()))?;
+            .sign(message);
         Ok(Self::to_base64(signature.as_ref()))
     }
 


### PR DESCRIPTION
This pull request updates the JWT signing implementation to use Ed25519 instead of ECDSA (P-256).
- CDP Docs for this are [here](https://docs.cdp.coinbase.com/get-started/authentication/overview)

Please let me know if any changes are needed. I am new to Rust, so any feedback is welcome and thank you for creating this crate. :smile: 